### PR TITLE
Remove matlab ldd.

### DIFF
--- a/config/easybuild/eb_hooks.py
+++ b/config/easybuild/eb_hooks.py
@@ -353,6 +353,7 @@ def matlab_postproc(ec, *args, **kwargs):
         ec.cfg['postinstallcmds'] = [
             'chmod -R u+w %(installdir)s',
             f"{ccr_init}/easybuild/setrpaths.sh --path %(installdir)s --add_origin",
+            f"mv %(installdir)s/bin/ldd %(installdir)s/bin/ldd.bak",
         ]
         print_msg("Using custom postproc command option for %s: %s", ec.name, ec.cfg['postinstallcmds'])
     else:


### PR DESCRIPTION
When running matlab on centos7 we were getting this error:

```
matlab -nodisplay -nojvm -batch "fprintf('hello\n')"
Fatal Startup Error:
Dynamic exception type: mwboost::exception_detail::clone_impl<fl::i18n::MessageCatalog::MessageCatalogIncorrectRoot>
std::exception::what: Incorrect Message Root Set
```

This was due to matlab's ldd getting picked up in the path and causing
link issues and ignoring the compat layer:

```
$ ldd $EBROOTMATLAB/bin/glnxa64/MATLAB | grep -v cvmfs
	linux-vdso.so.1 =>  (0x00007fff49dfb000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f1ba47d5000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f1ba3e22000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007f1ba3bf7000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f1b9f316000)
	librt.so.1 => /lib64/librt.so.1 (0x00007f1b9f10d000)
	libcrypt.so.1 => /lib64/libcrypt.so.1 (0x00007f1b9cfb0000)
	libpam.so.0 => /lib64/libpam.so.0 (0x00007f1b9cda1000)
	libz.so.1 => /lib64/libz.so.1 (0x00007f1b9c6d8000)
	libfreebl3.so => /lib64/libfreebl3.so (0x00007f1b9b3d2000)
	libaudit.so.1 => /lib64/libaudit.so.1 (0x00007f1b9b1a8000)
	libcap-ng.so.0 => /lib64/libcap-ng.so.0 (0x00007f1b9af86000)
```

Moving matlab's ldd out of the way fixes the issue and doesn't appear to
cause any adverse side effects:

```
$ mv $EBROOTMATLAB/bin/ldd $EBROOTMATLAB/bin/ldd.bak
$ ldd $EBROOTMATLAB/bin/glnxa64/MATLAB | grep -v cvmfs
	linux-vdso.so.1 (0x00007fffb5dc4000)

$ matlab -nodisplay -nojvm -batch "fprintf('hello\n')"
hello
```