### PR TITLE
Fix link error when building Perl.

### DIFF
--- a/config/easybuild/eb_hooks.py
+++ b/config/easybuild/eb_hooks.py
@@ -167,6 +167,14 @@ def cuda_config_opts(ec, prefix):
     else:
         raise EasyBuildError("cuda-specific hook triggered for non-cuda easyconfig?!")
 
+def perl_config_opts(ec, prefix):
+    """Custom config options for Perl."""
+    if ec.name != 'Perl':
+        raise EasyBuildError("perl-specific hook triggered for non-perl easyconfig?!")
+
+    print_msg(f"Set path to openssl in compat layer for Perl {ec.version}..")
+    setvar("EBROOTOPENSSL", f"{prefix}/usr")
+
 def matlab_config_opts(ec, prefix):
     """Custom config options for MATLAB."""
     if ec.name != 'MATLAB':
@@ -394,6 +402,7 @@ PARSE_HOOKS = {
     'PMIx': pmix_config_opts,
     'CUDA': cuda_config_opts,
     'MATLAB': matlab_config_opts,
+    'Perl': perl_config_opts,
 }
 
 PRE_CONFIGURE_HOOKS = {


### PR DESCRIPTION
Building Perl-5.34.0-GCCcore-11.2.0.eb was failing with the following error:

```
LD_RUN_PATH="/lib64" gcc  -shared -O2 --sysroot=/cvmfs/soft.ccr.buffalo.edu/versions/2022.05/compat -L/lib64 -L/lib -L/cvmfs/soft.ccr.buffalo.edu/versions/2022.05/compat/usr/local/lib -fstack-protector-strong  SSLeay.o  -o blib/arch/auto/Net/SSLeay/SSLeay.so  \
   -L/lib64 -L/lib -lssl -lcrypto -lz   \

/cvmfs/soft.ccr.buffalo.edu/versions/2022.05/compat/usr/bin/ld.gold: error: cannot open /usr/lib64/libc_nonshared.a: No such file or directory
collect2: error: ld returned 1 exit status
```

This was due to the following:

1. We filter out OpenSSL in filter-deps

2. Net::SSleay requires OpenSSL

3. EasyBuild config sets the path to openssl headers files [here](https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/p/Perl/Perl-5.34.0-GCCcore-11.2.0.eb#L402)

4. Because we don't use the openssl easybuild module `EBROOTOPENSSL` was empty and Net::SSLeay was finding the openssl headers on the host instead of the compat layer and adding in the following link flags `-L/lib64 -L/lib`.

5. The link flags added above caused the linker to look for `/usr/lib64/libc_nonshared.a` on the host instead of the compat layer, causing the erroneous ld.gold link error.

To fix this, we simply set the `EBROOTOPENSSL` env variable to point at the compat layer so Net::SSLeay builds against the correct openssl library.