### PR TITLE
Add hook for anaconda3 to fix terminfo.

### DIFF
--- a/config/easybuild/eb_hooks.py
+++ b/config/easybuild/eb_hooks.py
@@ -32,6 +32,11 @@ CUSTOMEB_MODLUAFOOTER  = """
 prepend_path("PATH", pathJoin(os.getenv("CCR_INIT_DIR"), "easybuild/bin"))
 """
 
+ANACONDA_MODLUAFOOTER  = """
+
+setenv("TERMINFO", pathJoin(os.getenv("EPREFIX"), "usr/share/terminfo"))
+"""
+
 MPI_MODLUAFOOTER = """
 
 add_property("type_","mpi")
@@ -70,6 +75,9 @@ def set_modluafooter(ec):
 
     if name == 'easybuild':
         ec['modluafooter'] += (CUSTOMEB_MODLUAFOOTER)
+
+    if name == 'anaconda3':
+        ec['modluafooter'] += (ANACONDA_MODLUAFOOTER)
 
     if name == 'openmpi':
         ec['modluafooter'] += (MPI_MODLUAFOOTER)


### PR DESCRIPTION
When loading anaconda3 module hit an issue with the terminfo/termcap files. [This issue](https://github.com/ContinuumIO/anaconda-issues/issues/331) summarizes it nicely and the fix is to set TERMINFO env var.

This commit adds a hook to set TERMINFO in the anaconda module file.