### PR TITLE
RSEM version 1.3.3

### DIFF
--- a/config/easybuild/easyconfigs/HISAT2-2.2.1-gompi-2021b.eb
+++ b/config/easybuild/easyconfigs/HISAT2-2.2.1-gompi-2021b.eb
@@ -1,0 +1,65 @@
+##
+# This is a contribution from DeepThought HPC Service, Flinders University, Adelaide, Australia
+# Homepage: 	https://staff.flinders.edu.au/research/deep-thought
+#
+# Authors::	Robert Qiao <rob.qiao@flinders.edu.au>
+# License::	GPLv3.0
+#
+# Notes::
+# 2.2.1 - changes from Adam Huffman <adam.huffman@bdi.ox.ac.uk>
+# Bumped to foss-2021b
+# J. Sassmannshausen
+
+easyblock = 'MakeCp'
+
+name = 'HISAT2'
+version = '2.2.1'
+
+homepage = 'https://daehwankimlab.github.io/hisat2'
+description = """HISAT2 is a fast and sensitive alignment program for mapping next-generation sequencing reads
+ (both DNA and RNA) against the general human population (as well as against a single reference genome)."""
+
+toolchain = {'name': 'gompi', 'version': '2021b'}
+
+sources = [{
+    'source_urls': ['https://cloud.biohpc.swmed.edu/index.php/s/fE9QCsX3NH4QwBi'],
+    'download_filename': 'download',
+    'filename': '%(namelower)s-%(version)s-source.zip',
+}]
+patches = [
+    'hisat2-libname-fix.patch',
+]
+checksums = [
+    '48e933330d4d8470d2b3dfe7ec3918f2e98a75f7381891e23b7df1fb4f135eb1',
+    '8aa91d1dd6455b96c10ce48827f8313b006241d815fbe6382422dbae3b610726',  # hisat2-libname-fix.patch
+]
+
+dependencies = [
+    ('NGS', '2.11.2'),
+    ('ncbi-vdb', '3.0.5'),
+    ('SRA-Toolkit', '3.0.5')
+]
+
+#buildopts = 'CC="$CC" CPP="$CXX" RELEASE_FLAGS="$CFLAGS" '
+#buildopts = 'CC="$CC" CPP="$CXX" RELEASE_FLAGS="$CFLAGS -Wno-deprecated" '
+#buildopts = 'CC="$CC" CPP="$CXX" RELEASE_FLAGS="$CFLAGS -Wno-XXX" '
+#buildopts = 'CC="$CC" CPP="$CXX" RELEASE_FLAGS="$CFLAGS -fsyntax-only" '
+buildopts = 'CC="$CC" CPP="$CXX" '
+buildopts += 'RELEASE_FLAGS="$CFLAGS -w -I${EBROOTSRAMINTOOLKIT}/include -L${EBROOTSRAMINTOOLKIT}/lib64 -lncbi-ngs -lngs-c++" '
+buildopts += "USE_SRA=1 NCBI_NGS_DIR=$EBROOTNGS NCBI_VDB_DIR=$EBROOTNCBIMINVDB"
+
+local_executables = ['hisat2', 'hisat2-align-l', 'hisat2-align-s', 'hisat2-build', 'hisat2-build-l', 'hisat2-build-s',
+                     'hisat2-inspect', 'hisat2-inspect-s', 'hisat2-inspect-l', 'hisat2-repeat', 'extract_exons.py',
+                     'extract_splice_sites.py', 'hisat2_extract_exons.py', 'hisat2_extract_snps_haplotypes_UCSC.py',
+                     'hisat2_extract_snps_haplotypes_VCF.py', 'hisat2_extract_splice_sites.py',
+                     'hisat2_read_statistics.py', 'hisat2_simulate_reads.py']
+files_to_copy = [(local_executables, 'bin'), 'scripts', 'example']
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in local_executables],
+    'dirs': ['scripts', 'example'],
+}
+
+sanity_check_commands = ["hisat2 --help"]
+
+moduleclass = 'bio'

--- a/config/easybuild/easyconfigs/RSEM-1.3.3-foss-2021b.eb
+++ b/config/easybuild/easyconfigs/RSEM-1.3.3-foss-2021b.eb
@@ -1,0 +1,51 @@
+##
+# This is a contribution from DeepThought HPC Service, Flinders University, Adelaide, Australia
+# Homepage: 	https://staff.flinders.edu.au/research/deep-thought
+#
+# Authors::	Robert Qiao <rob.qiao@flinders.edu.au>
+# License::	GPLv3.0
+#
+# Notes::
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'RSEM'
+version = '1.3.3'
+
+homepage = 'https://deweylab.github.io/RSEM/'
+description = "RNA-Seq by Expectation-Maximization"
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+toolchainopts = {'openmp': True}
+
+source_urls = ['https://github.com/deweylab/RSEM/archive/']
+sources = ['v%(version)s.tar.gz']
+patches = ['RSEM-1.3.0_makefiles.patch']
+checksums = [
+    '90e784dd9df8346caa2a7e3ad2ad07649608a51df1c69bfb6e16f45e611a40dc',  # v1.3.3.tar.gz
+    '2d244659206c78655b92f1bd519ee65f28a6b5f9418dfad04e887b64eca6641b',  # RSEM-1.3.0_makefiles.patch
+]
+
+skipsteps = ['configure']
+
+installopts = "prefix=%(installdir)s"
+
+dependencies = [
+    ('ncurses', '6.2'),
+    ('zlib', '1.2.11'),
+    ('Perl', '5.34.0'),
+    ('R', '4.2.0'),
+    ('HISAT2', '2.2.1'),
+    ('STAR', '2.7.9a'),
+    ('Bowtie2', '2.4.4'),
+    ('Bowtie', '1.3.1'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/rsem-calculate-expression', 'bin/rsem-plot-model', 'bin/rsem-plot-transcript-wiggles',
+              'bin/rsem-bam2wig', 'bin/rsem-generate-data-matrix', 'bin/rsem-run-em', 'bin/convert-sam-for-rsem'],
+    'dirs': ['bin/samtools-1.3'],
+}
+
+moduleclass = 'bio'

--- a/config/easybuild/easyconfigs/SRA-Toolkit-3.0.5-gompi-2021b.eb
+++ b/config/easybuild/easyconfigs/SRA-Toolkit-3.0.5-gompi-2021b.eb
@@ -41,7 +41,6 @@ dependencies = [
 
 configopts = '-DVDB_INCDIR="$EBROOTNCBIMINVDB/include" -DVDB_LIBDIR="$EBROOTNCBIMINVDB/lib" '
 configopts += '-DBUILD_TOOLS_LOADERS=ON -DBUILD_TOOLS_INTERNAL=ON '
-configopts += "-DDEFAULT_SYSROOT=$EPREFIX "
 
 _sra_bin = [
     'abi-dump', 'abi-load', 'align-info', 'bam-load', 'cache-mgr', 'cg-load', 'copycat', 'fasterq-dump', 'fastq-dump',

--- a/config/easybuild/easyconfigs/SRA-Toolkit-3.0.5-gompi-2021b.eb
+++ b/config/easybuild/easyconfigs/SRA-Toolkit-3.0.5-gompi-2021b.eb
@@ -1,0 +1,70 @@
+# updated: Denis Kristak (INUITS)
+# updated: Sebastien Moretti (SIB - Vital-IT)
+easyblock = 'CMakeMake'
+
+name = 'SRA-Toolkit'
+version = '3.0.5'
+
+homepage = 'https://github.com/ncbi/sra-tools'
+description = """The SRA Toolkit, and the source-code SRA System Development
+ Kit (SDK), will allow you to programmatically access data housed within SRA
+ and convert it from the SRA format"""
+github_account = 'ncbi'
+
+toolchain = {'name': 'gompi', 'version': '2021b'}
+toolchainopts = {'extra_cflags': '-DH5_USE_110_API'}
+
+source_urls = ['https://github.com/ncbi/sra-tools/archive/refs/tags/']
+sources = [{'download_filename': '%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}]
+checksums = [
+    {'SRA-Toolkit-3.0.5.tar.gz': '6dca9889ca9cfa83e9ce1c39bf7ae5654576fc79c4f608e902272a49573a05e0'},
+]
+
+builddependencies = [
+    ('CMake', '3.22.1'),
+    ('flex', '2.6.4'),
+    ('Bison', '3.7.6'),
+    ('Perl', '5.34.0', '-minimal'),
+    ('Python', '3.9.6', '-bare'),
+]
+
+dependencies = [
+    ('Java', '11.0.16', '', SYSTEM),
+    ('OpenSSL', '1.1', '', SYSTEM),
+    ('ncbi-vdb', version),
+    ('bzip2', '1.0.8'),
+    ('file', '5.41'),
+    ('HDF5', '1.12.1'),
+    ('libxml2', '2.9.10'),
+    ('zlib', '1.2.11'),
+]
+
+configopts = '-DVDB_INCDIR="$EBROOTNCBIMINVDB/include" -DVDB_LIBDIR="$EBROOTNCBIMINVDB/lib" '
+configopts += '-DBUILD_TOOLS_LOADERS=ON -DBUILD_TOOLS_INTERNAL=ON '
+configopts += "-DDEFAULT_SYSROOT=$EPREFIX "
+
+_sra_bin = [
+    'abi-dump', 'abi-load', 'align-info', 'bam-load', 'cache-mgr', 'cg-load', 'copycat', 'fasterq-dump', 'fastq-dump',
+    'fastq-load', 'helicos-load', 'illumina-dump', 'illumina-load', 'kar', 'kdbmeta', 'latf-load', 'pacbio-load',
+    'prefetch', 'rcexplain', 'sam-dump', 'sff-dump', 'sff-load', 'srapath', 'sra-pileup', 'sra-sort', 'sra-stat',
+    'sratools', 'srf-load', 'test-sra', 'vdb-config', 'vdb-copy', 'vdb-decrypt', 'vdb-dump', 'vdb-encrypt', 'vdb-lock',
+    'vdb-unlock', 'vdb-validate',
+]
+
+_ngs_libs = ['libncbi-ngs.a', 'libncbi-ngs-c++.a', 'libncbi-ngs.%s' % SHLIB_EXT,
+             'libngs-c++.a', 'libngs-c++.%s' % SHLIB_EXT]
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in _sra_bin] + ['lib/%s' % l for l in _ngs_libs],
+    'dirs': ['jar', 'include/ncbi-vdb', 'include/ngs']
+}
+
+sanity_check_commands = [
+    "abi-dump --help",
+    "kar --help",
+    "sra-sort --help",
+]
+
+modextrapaths = {'CLASSPATH': 'jar/ngs-java.jar'}
+
+moduleclass = 'bio'

--- a/config/easybuild/easyconfigs/hisat2-libname-fix.patch
+++ b/config/easybuild/easyconfigs/hisat2-libname-fix.patch
@@ -1,0 +1,15 @@
+removes static from lib names as it caused problems when linking
+J. Sassmannshausen
+diff --git a/hisat2-2.2.1.orig/Makefile b/hisat2-2.2.1/Makefile
+index 60445ce..0b422f8 100644
+--- a/hisat2-2.2.1.orig/Makefile
++++ b/hisat2-2.2.1/Makefile
+@@ -94,7 +94,7 @@ SRA_LIB =
+ SERACH_INC = 
+ ifeq (1,$(USE_SRA))
+ 	SRA_DEF = -DUSE_SRA
+-	SRA_LIB = -lncbi-ngs-c++-static -lngs-c++-static -lncbi-vdb-static -ldl
++	SRA_LIB = -lncbi-ngs-c++ -lngs-c++ -lncbi-vdb -ldl
+ 	SEARCH_INC += -I$(NCBI_NGS_DIR)/include -I$(NCBI_VDB_DIR)/include
+ 	SEARCH_LIBS += -L$(NCBI_NGS_DIR)/lib64 -L$(NCBI_VDB_DIR)/lib64
+ endif

--- a/config/easybuild/easyconfigs/ncbi-vdb-3.0.5-gompi-2021b.eb
+++ b/config/easybuild/easyconfigs/ncbi-vdb-3.0.5-gompi-2021b.eb
@@ -1,0 +1,41 @@
+easyblock = 'CMakeMake'
+
+name = 'ncbi-vdb'
+version = '3.0.5'
+
+homepage = 'https://github.com/ncbi/ncbi-vdb'
+description = """The SRA Toolkit and SDK from NCBI is a collection of tools and libraries for
+ using data in the INSDC Sequence Read Archives."""
+
+toolchain = {'name': 'gompi', 'version': '2021b'}
+
+github_account = 'ncbi'
+source_urls = [GITHUB_SOURCE]
+sources = [{'download_filename': '%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ}]
+checksums = ['a32672d7f76507a77ceb29f023855eaf5bf4d150ddd21b55c013b499f3b83735']
+
+builddependencies = [
+    ('Perl', '5.34.0', '-minimal'),
+    ('Python', '3.9.6', '-bare'),
+    ('CMake', '3.22.1'),
+]
+
+dependencies = [
+    ('NGS', '2.11.2'),
+    ('file', '5.41'),  # provides libmagic
+    ('HDF5', '1.12.1'),
+    ('libxml2', '2.9.10'),
+    ('bzip2', '1.0.8'),
+]
+
+configopts = "-DHDF5_INCDIR=$EBROOTHDF5/include -DHDF5_LIBDIR=$EBROOTHDF5/lib "
+configopts += "-DXML2_INCDIR=$EBROOTLIBXML2/include -DXML2_LIBDIR=$EBROOTLIBXML2/lib "
+configopts += "-DDEFAULT_SYSROOT=$EPREFIX "
+
+sanity_check_paths = {
+    'files': ['include/ncbi/ncbi.h', 'include/ncbi/vdb-blast.h'] +
+             [('lib/libncbi-%s.%s' % (k, e)) for k in ['vdb', 'wvdb'] for e in ['a', SHLIB_EXT]],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/config/easybuild/easyconfigs/ncbi-vdb-3.0.5-gompi-2021b.eb
+++ b/config/easybuild/easyconfigs/ncbi-vdb-3.0.5-gompi-2021b.eb
@@ -30,7 +30,6 @@ dependencies = [
 
 configopts = "-DHDF5_INCDIR=$EBROOTHDF5/include -DHDF5_LIBDIR=$EBROOTHDF5/lib "
 configopts += "-DXML2_INCDIR=$EBROOTLIBXML2/include -DXML2_LIBDIR=$EBROOTLIBXML2/lib "
-configopts += "-DDEFAULT_SYSROOT=$EPREFIX "
 
 sanity_check_paths = {
     'files': ['include/ncbi/ncbi.h', 'include/ncbi/vdb-blast.h'] +


### PR DESCRIPTION
RSEM version 1.3.3

Note that ncbi-vdb has split into two - ncbi-vdb and sra-tools since version 3 as per:
  https://github.com/ncbi/ncbi-vdb

I added sra-tools to the requirements for HISAT2 and added the include, library and library paths to sra-tools.
Note that HISAT2 is in desperately needs work - it uses deprecated functions, makes incompatible type comparisons etc. - I can only get it to copmile with "-w" which means ignore all warnings!

Tony