### PR TITLE
pymbar 3.1.1 and 4.0.2 builds

### DIFF
--- a/config/easybuild/easyconfigs/numexpr-2.8.1-foss-2021b.eb
+++ b/config/easybuild/easyconfigs/numexpr-2.8.1-foss-2021b.eb
@@ -1,0 +1,21 @@
+name = 'numexpr'
+version = '2.8.1'
+
+homepage = 'https://numexpr.readthedocs.io/en/latest/'
+description = """The numexpr package evaluates multiple-operator array expressions many times faster than NumPy can.
+ It accepts the expression as a string, analyzes it, rewrites it more efficiently, and compiles it on the fly into
+ code for its internal virtual machine (VM). Due to its integrated just-in-time (JIT) compiler, it does not require a
+ compiler at runtime."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+source_urls = ['https://github.com/pydata/numexpr/archive/refs/tags']
+sources = ['v%(version)s.tar.gz']
+checksums = ['a416a869f4e6a488af7cd876a326fb82f892b23570b68eecff8135c4a39dd161']
+
+dependencies = [
+    ('Python',       '3.9.6'),
+    ('SciPy-bundle', '2021.10'),
+]
+
+moduleclass = 'math'

--- a/config/easybuild/easyconfigs/pymbar-3.1.1-foss-2021b-Python-3.9.6.eb
+++ b/config/easybuild/easyconfigs/pymbar-3.1.1-foss-2021b-Python-3.9.6.eb
@@ -1,0 +1,39 @@
+easyblock = 'PythonPackage'
+
+name = 'pymbar'
+version = '3.1.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://pymbar.readthedocs.io/en/master/'
+description = """The pymbar package contains the pymbar suite of tools for the analysis of
+simulated and experimental data with the multistate Bennett acceptance
+ratio (MBAR) estimator."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+source_urls = ['https://github.com/choderalab/pymbar/archive/']
+sources = ['%(version)s.tar.gz']
+patches = [
+    'pymbar-3.1.1_use-mamba-to-build-docs-on-the-lts-branch.patch',  # commit 035876880534ff0ec0121a5724cc29574aaf754d
+]
+checksums = [
+    'a888b316bb4b0469744597ca8de04affc95eaa3c65974f2b0c63c8e44f20fbfc',  # Source tarball
+    '6e15c9a6e64ae40449541324dc3c8083a9e4b1ce0819ef591a1a0956c14b8f5f',  # pymbar-3.1.1_use-mamba-to-build-docs-on-the-lts-branch.patch
+]
+
+dependencies = [
+    ('Python', '3.9.6'),
+    ('numexpr', '2.8.1'),
+]
+
+download_dep_fail = True
+use_pip = True
+
+sanity_pip_check = True
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'chem'

--- a/config/easybuild/easyconfigs/pymbar-3.1.1_use-mamba-to-build-docs-on-the-lts-branch.patch
+++ b/config/easybuild/easyconfigs/pymbar-3.1.1_use-mamba-to-build-docs-on-the-lts-branch.patch
@@ -1,0 +1,275 @@
+From 035876880534ff0ec0121a5724cc29574aaf754d Mon Sep 17 00:00:00 2001
+From: Mike Henry <11765982+mikemhenry@users.noreply.github.com>
+Date: Thu, 16 Mar 2023 16:12:06 -0700
+Subject: [PATCH] use mamba to build docs on the lts branch (#495)
+
+* use mamba to build docs on the lts branch
+
+* looks like we need to update statsmodels
+
+* remove np.int
+
+* missed and np.int
+
+* update to work with newer versions of stat tools
+---
+ .readthedocs.yml                              | 19 ++++++++++
+ devtools/conda-envs/test_env.yaml             |  5 ++-
+ pymbar/tests/test_mbar.py                     |  2 +-
+ .../testsystems/exponential_distributions.py  |  8 ++--
+ pymbar/testsystems/harmonic_oscillators.py    |  2 +-
+ pymbar/timeseries.py                          | 38 +++++++++----------
+ 6 files changed, 48 insertions(+), 26 deletions(-)
+ create mode 100644 .readthedocs.yml
+
+diff --git a/.readthedocs.yml b/.readthedocs.yml
+new file mode 100644
+index 00000000..2954ec36
+--- /dev/null
++++ b/.readthedocs.yml
+@@ -0,0 +1,19 @@
++# .readthedocs.yml
++
++version: 2
++
++build:
++  os: "ubuntu-20.04"
++  tools:
++    python: "mambaforge-4.10"
++
++python:
++  install:
++    - method: pip
++      path: .
++
++sphinx:
++   configuration: docs/conf.py
++
++conda:
++  environment: devtools/conda-envs/test_env.yaml
+diff --git a/devtools/conda-envs/test_env.yaml b/devtools/conda-envs/test_env.yaml
+index 88b9b8ec..7b6fb7f9 100644
+--- a/devtools/conda-envs/test_env.yaml
++++ b/devtools/conda-envs/test_env.yaml
+@@ -14,7 +14,10 @@ dependencies:
+   - pytest-cov
+   - flaky
+   - codecov
+-  - statsmodels <0.13
++  - statsmodels 
+   - scikit-learn  # Provides the sklearn module
+   - matplotlib-base
+   - xlrd
++    # Docs
++  - numpydoc
++  - sphinxcontrib-bibtex
+diff --git a/pymbar/tests/test_mbar.py b/pymbar/tests/test_mbar.py
+index 9f6e6a9d..a8fed476 100644
+--- a/pymbar/tests/test_mbar.py
++++ b/pymbar/tests/test_mbar.py
+@@ -374,7 +374,7 @@ def test_mbar_computePMF():
+     xmin = test.O_k[refstate] - 1
+     xmax = test.O_k[refstate] + 1
+     within_bounds = (x_n >= xmin) & (x_n < xmax)
+-    bin_centers = dx*np.arange(np.int(xmin/dx),np.int(xmax/dx)) + dx/2
++    bin_centers = dx*np.arange(int(xmin/dx),int(xmax/dx)) + dx/2
+     bin_n = np.zeros(len(x_n),int)
+     bin_n[within_bounds] = 1 + np.floor((x_n[within_bounds]-xmin)/dx)
+     # 0 is reserved for samples outside the domain.  We will ignore this state
+diff --git a/pymbar/testsystems/exponential_distributions.py b/pymbar/testsystems/exponential_distributions.py
+index 4963d825..2d186be8 100644
+--- a/pymbar/testsystems/exponential_distributions.py
++++ b/pymbar/testsystems/exponential_distributions.py
+@@ -114,7 +114,7 @@ def sample(self, N_k=(10, 20, 30, 40, 50), mode='u_kln', seed=None):
+         N_k : np.ndarray, shape=(n_states), dtype=float
+            N_k[k] is the number of samples generated from state k
+         s_n : np.ndarray, shape=(n_samples), dtype='int'
+-            s_n is the state of origin of x_n           
++            s_n is the state of origin of x_n
+ 
+         x_kn : np.ndarray, shape=(n_states, n_samples), dtype=float
+             1D harmonic oscillator positions
+@@ -138,7 +138,7 @@ def sample(self, N_k=(10, 20, 30, 40, 50), mode='u_kln', seed=None):
+         x_kn = np.zeros([self.n_states, N_max], np.float64)
+         u_kln = np.zeros([self.n_states, self.n_states, N_max], np.float64)
+         x_n = np.zeros([N_tot], np.float64)
+-        s_n = np.zeros([N_tot], np.int)
++        s_n = np.zeros([N_tot], int)
+         u_kn = np.zeros([self.n_states, N_tot], np.float64)
+         index = 0
+         for k, N in enumerate(N_k):
+@@ -160,7 +160,7 @@ def sample(self, N_k=(10, 20, 30, 40, 50), mode='u_kln', seed=None):
+             raise Exception("Unknown mode '{}'".format(mode))
+ 
+         return
+-    
++
+     @classmethod
+     def evenly_spaced_exponentials(cls, n_states, n_samples_per_state, lower_rate=1.0, upper_rate=3.0):
+         """Generate samples from evenly spaced exponential distributions.
+@@ -196,7 +196,7 @@ def evenly_spaced_exponentials(cls, n_states, n_samples_per_state, lower_rate=1.
+         s_n : np.ndarray, shape=(n_samples)
+             State of origin of each sample
+         """
+-                
++
+         name = "%dx%d exponentials" % (n_states, n_samples_per_state)
+ 
+         rates = np.linspace(lower_rate, upper_rate, n_states)
+diff --git a/pymbar/testsystems/harmonic_oscillators.py b/pymbar/testsystems/harmonic_oscillators.py
+index 6192d286..0b8e2d24 100644
+--- a/pymbar/testsystems/harmonic_oscillators.py
++++ b/pymbar/testsystems/harmonic_oscillators.py
+@@ -145,7 +145,7 @@ def sample(self, N_k=[10, 20, 30, 40, 50], mode='u_kn', seed = None):
+         x_kn = np.zeros([self.n_states, N_max], np.float64)
+         u_kln = np.zeros([self.n_states, self.n_states, N_max], np.float64)
+         x_n = np.zeros([N_tot], np.float64)
+-        s_n = np.zeros([N_tot], np.int)
++        s_n = np.zeros([N_tot], int)
+         u_kn = np.zeros([self.n_states, N_tot], np.float64)
+         index = 0
+         for k, N in enumerate(N_k):
+diff --git a/pymbar/timeseries.py b/pymbar/timeseries.py
+index d1e3ddeb..aaf1f482 100644
+--- a/pymbar/timeseries.py
++++ b/pymbar/timeseries.py
+@@ -84,7 +84,7 @@ def statisticalInefficiency(A_n, B_n=None, fast=False, mintime=3, fft=False):
+     B_n : np.ndarray, float, optional, default=None
+         B_n[n] is nth value of timeseries B.  Length is deduced from vector.
+         If supplied, the cross-correlation of timeseries A and B will be estimated instead of the
+-        autocorrelation of timeseries A.  
++        autocorrelation of timeseries A.
+     fast : bool, optional, default=False
+         f True, will use faster (but less accurate) method to estimate correlation
+         time, described in Ref. [1] (default: False).  This is ignored
+@@ -118,7 +118,7 @@ def statisticalInefficiency(A_n, B_n=None, fast=False, mintime=3, fft=False):
+     Examples
+     --------
+ 
+-    Compute statistical inefficiency of timeseries data with known correlation time.  
++    Compute statistical inefficiency of timeseries data with known correlation time.
+ 
+     >>> from pymbar.testsystems import correlated_timeseries_example
+     >>> A_n = correlated_timeseries_example(N=100000, tau=5.0)
+@@ -130,7 +130,7 @@ def statisticalInefficiency(A_n, B_n=None, fast=False, mintime=3, fft=False):
+     A_n = np.array(A_n)
+ 
+     if fft and B_n is None:
+-        return statisticalInefficiency_fft(A_n, mintime=mintime)    
++        return statisticalInefficiency_fft(A_n, mintime=mintime)
+ 
+     if B_n is not None:
+         B_n = np.array(B_n)
+@@ -741,7 +741,7 @@ def detectEquilibration(A_t, fast=True, nskip=1):
+ 
+     Parameters
+     ----------
+-    A_t : np.ndarray 
++    A_t : np.ndarray
+         timeseries
+     nskip : int, optional, default=1
+         number of samples to sparsify data by in order to speed equilibration detection
+@@ -753,7 +753,7 @@ def detectEquilibration(A_t, fast=True, nskip=1):
+     g : float
+         statistical inefficiency of equilibrated data
+     Neff_max : float
+-        number of uncorrelated samples   
++        number of uncorrelated samples
+ 
+     ToDo
+     ----
+@@ -763,7 +763,7 @@ def detectEquilibration(A_t, fast=True, nskip=1):
+     -----
+     If your input consists of some period of equilibration followed by
+     a constant sequence, this function treats the trailing constant sequence
+-    as having Neff = 1.  
++    as having Neff = 1.
+ 
+     Examples
+     --------
+@@ -817,8 +817,8 @@ def statisticalInefficiency_fft(A_n, mintime=3, memsafe=None):
+         correlation function first goes negative.  Note that this time may need to be increased
+         if there is a strong initial negative peak in the correlation function.
+     memsafe: bool, optional, default=None (in depreciation)
+-        If this function is used several times on arrays of comparable size then one might benefit 
+-        from setting this option to False. If set to True then clear np.fft cache to avoid a fast 
++        If this function is used several times on arrays of comparable size then one might benefit
++        from setting this option to False. If set to True then clear np.fft cache to avoid a fast
+         increase in memory consumption when this function is called on many arrays of different sizes.
+ 
+     Returns
+@@ -851,7 +851,7 @@ def statisticalInefficiency_fft(A_n, mintime=3, memsafe=None):
+     # Get the length of the timeseries.
+     N = A_n.size
+ 
+-    C_t = sm.tsa.stattools.acf(A_n, fft=True, unbiased=True, nlags=N)
++    C_t = sm.tsa.stattools.acf(A_n, fft=True, adjusted=True, nlags=N)
+     t_grid = np.arange(N).astype('float')
+     g_t = 2.0 * C_t * (1.0 - t_grid / float(N))
+ 
+@@ -873,7 +873,7 @@ def statisticalInefficiency_fft(A_n, mintime=3, memsafe=None):
+         warnings.warn("NumPy's FFT pack now uses an LRU cache to fix the very problem that the memsafe keyword "
+                       "was protecting. This argument no longer changes the code and will be removed in a future "
+                       "version.", FutureWarning)
+-    
++
+     try:
+         ind = np.where((C_t <= 0) & (t_grid > mintime))[0][0]
+     except IndexError:
+@@ -890,9 +890,9 @@ def detectEquilibration_binary_search(A_t, bs_nodes=10):
+ 
+     Parameters
+     ----------
+-    A_t : np.ndarray 
++    A_t : np.ndarray
+         timeseries
+-    
++
+     bs_nodes : int > 4
+         number of geometrically distributed binary search nodes
+ 
+@@ -904,7 +904,7 @@ def detectEquilibration_binary_search(A_t, bs_nodes=10):
+         statistical inefficiency of equilibrated data
+     Neff_max : float
+         number of uncorrelated samples
+-        
++
+     Notes
+     -----
+     Finds the discard region (t) by a binary search on the range of
+@@ -923,12 +923,12 @@ def detectEquilibration_binary_search(A_t, bs_nodes=10):
+     start = 1
+     end = T - 1
+     n_grid = min(bs_nodes, T)
+-    
++
+     while True:
+-        time_grid = np.unique((10 ** np.linspace(np.log10(start), np.log10(end), n_grid)).round().astype('int')) 
++        time_grid = np.unique((10 ** np.linspace(np.log10(start), np.log10(end), n_grid)).round().astype('int'))
+         g_t = np.ones(time_grid.size)
+         Neff_t = np.ones(time_grid.size)
+-        
++
+         for k, t in enumerate(time_grid):
+             if t < T-1:
+                 g_t[k] = statisticalInefficiency_fft(A_t[t:], memsafe=True)
+@@ -938,10 +938,10 @@ def detectEquilibration_binary_search(A_t, bs_nodes=10):
+         k = Neff_t.argmax()
+         t = time_grid[k]
+         g = g_t[k]
+-        
++
+         if (end - start < 4):
+             break
+-        
++
+         if k == 0:
+             start = time_grid[0]
+             end = time_grid[1]
+@@ -951,5 +951,5 @@ def detectEquilibration_binary_search(A_t, bs_nodes=10):
+         else:
+             start = time_grid[k - 1]
+             end = time_grid[k + 1]
+-        
++
+     return (t, g, Neff_max)

--- a/config/easybuild/easyconfigs/pymbar-4.0.2-foss-2021b-Python-3.9.6.eb
+++ b/config/easybuild/easyconfigs/pymbar-4.0.2-foss-2021b-Python-3.9.6.eb
@@ -1,0 +1,53 @@
+easyblock = 'PythonPackage'
+
+name = 'pymbar'
+version = '4.0.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://pymbar.readthedocs.io/en/master/'
+description = """The pymbar package contains the pymbar suite of tools for the analysis of
+simulated and experimental data with the multistate Bennett acceptance
+ratio (MBAR) estimator."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+source_urls = ['https://github.com/choderalab/pymbar/archive/']
+sources = [
+    '%(version)s.tar.gz',
+    # QQMBARobserve.pdf updated in commit e5b7f120f74442658a03c02b1a1898b5c2fa913a
+    {
+        'source_urls': ['https://github.com/choderalab/pymbar/blob/e5b7f120f74442658a03c02b1a1898b5c2fa913a/examples/harmonic-oscillators'],
+        'download_filename': 'QQMBARobserve.pdf',
+        'filename': 'QQMBARobserve.pdf',
+        'extract_cmd': 'install -m 644 %s "%(namelower)s-%(version)s/examples/harmonic-oscillators/QQMBARobserve.pdf"',
+    },
+
+
+]
+patches = [
+    'pymbar-4.0.2_fix-example-bug-and-updated-output.patch',  # commit e5b7f120f74442658a03c02b1a1898b5c2fa913a
+]
+checksums = [
+    '5a149f7e6a7b526c4f74d19a4e8652ead2e9ef0aceeb30f924518d45caa9d4d3',  # Source tarball
+    '8ff3e88ffa039ad73d73b2b546394a9efc085b75953cd83f5ab79acc895e974d',  # pQQMBARobserve.pdf
+    '1ed544a14533bb5c48f212987eda38c146c20901ea85d3bfe9591da114764a9d',  # pymbar-4.0.2_fix-example-bug-and-updated-output.patch
+]
+
+dependencies = [
+    ('Python', '3.9.6'),
+    ('numexpr', '2.8.1'),
+    ('jax', '0.4.16', '-CUDA-11.8.0'),
+    ('scikit-learn', '1.0.2'),
+]
+
+download_dep_fail = True
+use_pip = True
+
+sanity_pip_check = True
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'chem'

--- a/config/easybuild/easyconfigs/pymbar-4.0.2_fix-example-bug-and-updated-output.patch
+++ b/config/easybuild/easyconfigs/pymbar-4.0.2_fix-example-bug-and-updated-output.patch
@@ -1,0 +1,4467 @@
+From e5b7f120f74442658a03c02b1a1898b5c2fa913a Mon Sep 17 00:00:00 2001
+From: Michael Shirts <michael.shirts@colorado.edu>
+Date: Thu, 24 Aug 2023 11:18:15 -0600
+Subject: [PATCH] Fixed example bug and updated output. (#513)
+
+* Fixed example bug and updated output.
+
+fixed a bug in the harmonic_oscillators.py example that wasn't actually
+retrieving the data from the results object for reverse exponential averaging.
+
+Added logging to the two harmonic oscillator files.
+
+Update the output of the example scripts since they were quite old.
+
+* format fixes for black
+
+* fix doc building
+
+* we need to add html_theme since that gets injected later by RTD
+
+---------
+
+Co-authored-by: Mike Henry <11765982+mikemhenry@users.noreply.github.com>
+---
+ devtools/conda-envs/test_env_jax.yaml         |    3 +-
+ docs/conf.py                                  |    2 +-
+ .../harmonic-oscillators/QQMBARobserve.pdf    |  Bin 39119 -> 38891 bytes
+ examples/harmonic-oscillators/QQdf.pdf        |  Bin 120726 -> 120564 bytes
+ .../QQstandardobserve.pdf                     |  Bin 33364 -> 33462 bytes
+ ...mulative_probability_comparison_curves.pdf |  Bin 14395 -> 14392 bytes
+ .../harmonic-oscillators-distributions.py     |    5 +
+ ...ic-oscillators-distributions.py_output.txt | 2422 ++++++++++-------
+ .../harmonic-oscillators.py                   |    9 +-
+ .../harmonic-oscillators.py_output.txt        | 1420 ++++++----
+ 10 files changed, 2345 insertions(+), 1516 deletions(-)
+
+diff --git a/devtools/conda-envs/test_env_jax.yaml b/devtools/conda-envs/test_env_jax.yaml
+index c2dd795e..0ffe9f34 100644
+--- a/devtools/conda-envs/test_env_jax.yaml
++++ b/devtools/conda-envs/test_env_jax.yaml
+@@ -22,5 +22,6 @@ dependencies:
+   - xlrd
+     # Docs
+   - numpydoc
+-  - sphinx <7
++  - sphinx
++  - sphinx-rtd-theme
+   - sphinxcontrib-bibtex
+diff --git a/docs/conf.py b/docs/conf.py
+index 92a5919a..5fbe1a40 100644
+--- a/docs/conf.py
++++ b/docs/conf.py
+@@ -146,7 +146,7 @@
+ # a list of builtin themes.
+ # html_theme = "default"
+ on_rtd = os.environ.get("READTHEDOCS", None) == "True"
+-
++html_theme = "sphinx_rtd_theme"
+ if not on_rtd:  # only import and set the theme if we're building docs locally
+     import sphinx_rtd_theme
+ 
+diff --git a/examples/harmonic-oscillators/harmonic-oscillators-distributions.py b/examples/harmonic-oscillators/harmonic-oscillators-distributions.py
+index 181bbaa3..91a1efe4 100644
+--- a/examples/harmonic-oscillators/harmonic-oscillators-distributions.py
++++ b/examples/harmonic-oscillators/harmonic-oscillators-distributions.py
+@@ -34,6 +34,11 @@
+ from pymbar import testsystems, MBAR, confidenceintervals
+ from pymbar.utils import ParameterError, DataError
+ 
++import logging
++import sys
++
++logging.basicConfig(stream=sys.stdout, level=logging.INFO)
++
+ # =============================================================================================
+ # PARAMETERS
+ # =============================================================================================
+diff --git a/examples/harmonic-oscillators/harmonic-oscillators-distributions.py_output.txt b/examples/harmonic-oscillators/harmonic-oscillators-distributions.py_output.txt
+index 66050a67..dba7364b 100644
+--- a/examples/harmonic-oscillators/harmonic-oscillators-distributions.py_output.txt
++++ b/examples/harmonic-oscillators/harmonic-oscillators-distributions.py_output.txt
+@@ -1,5 +1,5 @@
+ Gaussian widths:
+-[ 0.2         0.25        0.33333333  0.5         1.          1.        ]
++[0.2        0.25       0.33333333 0.5        1.         1.        ]
+ Computing dimensionless free energies analytically...
+ This script will perform 200 replicates of an experiment where samples are drawn from 6 harmonic oscillators.
+ The harmonic oscillators have equilibrium positions
+@@ -10,815 +10,1230 @@ and the following number of samples will be drawn from each (can be zero if no s
+ [2000 2000 2000 2000 2000    0]
+ 
+ Performing replicate 1 / 200
+-[  0.03872209   1.04685416   4.12103712   9.20415087  16.68377262
+-  25.06687405]
+-[ 0.00119439  0.01076232  0.02579093  0.04837197  0.17128761  0.41789113]
++INFO:pymbar.mbar:Explicitly overwriting maxiter=10000 with maximum_iterations=10000
++INFO:pymbar.mbar:Explicitly overwriting maxiter=10000 with maximum_iterations=10000
++WARNING:pymbar.mbar_solvers:
++******* JAX 64-bit mode is now on! *******
++*     JAX is now set to 64-bit mode!     *
++*   This MAY cause problems with other   *
++*      uses of JAX in the same code.     *
++******************************************
++
++INFO:absl:Remote TPU is not linked into jax; skipping remote TPU.
++INFO:absl:Unable to initialize backend 'tpu_driver': Could not initialize backend 'tpu_driver'
++INFO:absl:Unable to initialize backend 'cuda': module 'jaxlib.xla_extension' has no attribute 'GpuAllocatorConfig'
++INFO:absl:Unable to initialize backend 'rocm': module 'jaxlib.xla_extension' has no attribute 'GpuAllocatorConfig'
++INFO:absl:Unable to initialize backend 'tpu': module 'jaxlib.xla_extension' has no attribute 'get_tpu_client'
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03975702  1.06089938  4.15772256  9.2692962  17.27135584 26.08738426]
++[0.00127191 0.01101887 0.02573263 0.04955805 0.17669491 0.48088857]
+ Performing replicate 2 / 200
+-[  0.03879351   1.06011432   4.13567374   9.29859965  16.7879643
+-  25.25336846]
+-[ 0.00118318  0.01057124  0.02609688  0.04868193  0.17017228  0.55549544]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03917819  1.03483151  4.08832227  9.24339671 16.83740492 26.7608673 ]
++[0.00118675 0.01060477 0.02551253 0.04938048 0.1780329  0.7321336 ]
+ Performing replicate 3 / 200
+-[  0.04061115   1.06267931   4.09118803   9.31631727  17.11739421
+-  26.34770003]
+-[ 0.00121496  0.01094449  0.02609262  0.049216    0.1778032   0.52499722]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.09e-12
++[ 0.04055724  1.06874178  4.08892222  9.2340339  16.84226148 25.66223138]
++[0.00122743 0.01085683 0.0258039  0.04863907 0.17568319 0.46901425]
+ Performing replicate 4 / 200
+-[  0.04023556   1.06041097   4.10851042   9.25855859  17.05498693
+-  25.94615061]
+-[ 0.00122054  0.0107666   0.02572417  0.04917176  0.17527207  0.50158067]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03859996  1.04319894  4.07635159  9.2704043  17.02365352 25.7952182 ]
++[0.00118064 0.01067002 0.02573458 0.04935639 0.17344164 0.679355  ]
+ Performing replicate 5 / 200
+-[  0.03647946   1.05641694   4.10395192   9.26248942  16.92409026
+-  26.70029366]
+-[ 0.0011224   0.01062546  0.02651769  0.04913448  0.17630464  0.72125854]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03999851  1.0581945   4.10142542  9.12112493 16.76162058 25.29394191]
++[0.00126098 0.01080304 0.02574235 0.04837199 0.17156425 0.52544919]
+ Performing replicate 6 / 200
+-[  0.04071179   1.0741896    4.10644023   9.25740792  17.26691921
+-  26.38829607]
+-[ 0.00122768  0.0109696   0.02558388  0.05002294  0.17694455  0.54839682]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.041259    1.06963024  4.13498272  9.23802983 17.28424224 25.63355068]
++[0.00128916 0.0110855  0.02590312 0.04896417 0.1746822  0.41399842]
+ Performing replicate 7 / 200
+-[  0.03852271   1.07731379   4.05550188   9.14657717  16.98357886
+-  25.68571325]
+-[ 0.00118577  0.0107274   0.02537818  0.04896032  0.17669887  0.45346642]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.03998083  1.05360812  4.15578022  9.2317178  16.86969683 26.28916118]
++[0.00125697 0.01091931 0.02603321 0.04961309 0.17438609 0.67755995]
+ Performing replicate 8 / 200
+-[  0.04189319   1.0422559    4.14801407   9.32298719  16.95873926
+-  25.52876044]
+-[ 0.00125463  0.01064661  0.02606403  0.04913193  0.17378307  0.45504856]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04034359  1.06466163  4.09885153  9.2462794  16.96509658 26.03139988]
++[0.0012728  0.01086498 0.0253186  0.04981314 0.17643884 0.54609721]
+ Performing replicate 9 / 200
+-[  0.03949911   1.05865144   4.10665833   9.26083539  16.77483914
+-  25.4414167 ]
+-[ 0.0012102   0.01094915  0.02516846  0.05049548  0.16926067  0.66967896]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03827445  1.0696382   4.08177677  9.23257688 16.68740565 25.63095153]
++[0.00116849 0.01092243 0.02583004 0.04874015 0.17440486 0.49292946]
+ Performing replicate 10 / 200
+-[  0.04096164   1.06280468   4.05615563   9.25905453  16.81709043
+-  25.69905597]
+-[ 0.00121286  0.01066403  0.02541121  0.04878758  0.17561748  0.44487128]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03952777  1.06343587  4.15480868  9.25953574 17.27640783 26.29958404]
++[0.00115818 0.01094069 0.02534381 0.04939131 0.1774903  0.51067183]
+ Performing replicate 11 / 200
+-[  0.0395926    1.05378135   4.12253523   9.30643066  16.86864261
+-  25.84667359]
+-[ 0.0012157   0.01054471  0.02617439  0.04923988  0.17454875  0.52326162]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04254579  1.06233906  4.11197514  9.30154172 16.95132393 26.09176338]
++[0.00129279 0.01089794 0.02639181 0.04849168 0.17521874 0.53253179]
+ Performing replicate 12 / 200
+-[  0.04116302   1.05230261   4.11942716   9.2614536   17.20360418
+-  27.36197648]
+-[ 0.00123948  0.01088472  0.0259626   0.04819764  0.18388569  0.74267001]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04046828  1.06779345  4.12316785  9.2144211  16.86481569 25.40279876]
++[0.00123747 0.01094135 0.02563493 0.04897413 0.17386576 0.4258853 ]
+ Performing replicate 13 / 200
+-[  0.03959043   1.07498064   4.12712509   9.25017716  17.03684815
+-  25.44762484]
+-[ 0.00122506  0.01053447  0.02585077  0.04890638  0.17236186  0.4605473 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.55e-12
++[ 0.04099892  1.05880623  4.12562008  9.20952558 16.77615539 25.29570702]
++[0.00123927 0.01108925 0.02569523 0.04881061 0.17428858 0.40893383]
+ Performing replicate 14 / 200
+-[  0.03925093   1.07331923   4.08678058   9.23983598  16.87978644
+-  25.41324602]
+-[ 0.00116227  0.01097319  0.02577474  0.04923042  0.17285919  0.45938337]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.0389926   1.06484681  4.13849916  9.20016077 17.22484414 26.82485627]
++[0.00123789 0.01087692 0.02592645 0.04918875 0.18099647 0.5793371 ]
+ Performing replicate 15 / 200
+-[  0.03762626   1.04784302   4.03419136   9.33848968  17.40656179
+-  26.36889993]
+-[ 0.00111624  0.01067943  0.02593927  0.05008926  0.17922841  0.44141555]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04098728  1.0636233   4.14960165  9.2277248  16.8589865  25.3040073 ]
++[0.00123771 0.01099136 0.02585176 0.04872039 0.1702846  0.50315912]
+ Performing replicate 16 / 200
+-[  0.03876492   1.06515491   4.09690167   9.27350331  16.77611792
+-  25.01321228]
+-[ 0.00117713  0.01075901  0.02563043  0.0495557   0.16873891  0.47542929]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03923365  1.06870702  4.14508531  9.24062163 17.43467359 26.9107548 ]
++[0.00119932 0.01091245 0.02550141 0.05070653 0.18124351 0.55588466]
+ Performing replicate 17 / 200
+-[  0.04117979   1.03454658   4.08782507   9.33505631  16.80413583
+-  25.06372215]
+-[ 0.00128456  0.01105017  0.02581496  0.0496832   0.16863834  0.46387006]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04066468  1.05613288  4.13959897  9.22756101 16.79427048 25.76637338]
++[0.00125339 0.01084751 0.02593038 0.04898718 0.17259343 0.61412782]
+ Performing replicate 18 / 200
+-[  0.04062881   1.07206111   4.0969758    9.24632326  17.31070092
+-  26.92703323]
+-[ 0.00119615  0.01108858  0.02562033  0.04919329  0.18085265  0.62970446]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04007358  1.052336    4.12959595  9.26827986 17.02631146 25.85213568]
++[0.00122838 0.01108661 0.02590686 0.04886313 0.17569385 0.47852126]
+ Performing replicate 19 / 200
+-[  0.04098208   1.05961615   4.12128125   9.30962447  16.94397297
+-  26.10232369]
+-[ 0.00130547  0.01062386  0.02598146  0.04859003  0.1754179   0.60580545]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04006776  1.05958605  4.1035124   9.23026567 17.041872   26.64703671]
++[0.00123073 0.01066059 0.0260152  0.04879449 0.17911898 0.61418207]
+ Performing replicate 20 / 200
+-[  0.04032528   1.0879548    4.10343721   9.27519979  17.10785345
+-  24.92711846]
+-[ 0.00118806  0.01079223  0.02565946  0.05027662  0.16847159  0.40262822]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.0406548   1.06954475  4.11681392  9.21439386 17.15610343 26.54183819]
++[0.00124471 0.01088371 0.0253197  0.04956307 0.17889697 0.72991734]
+ Performing replicate 21 / 200
+-[  0.04192865   1.08243361   4.10875391   9.13949752  16.73047727
+-  25.25316306]
+-[ 0.00125237  0.01112332  0.02530055  0.04940065  0.17186284  0.47276263]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04049427  1.03817909  4.10857467  9.21315947 17.01920751 25.83964872]
++[0.00121153 0.01078787 0.02540604 0.04946169 0.17563293 0.50729575]
+ Performing replicate 22 / 200
+-[  0.04118777   1.06384005   4.06494675   9.23753441  16.91621066
+-  25.3139594 ]
+-[ 0.00119204  0.01106297  0.02513047  0.04994734  0.17268006  0.41454497]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04048135  1.05300501  4.07589649  9.19926947 16.89512108 25.21236681]
++[0.00122891 0.01072923 0.02541592 0.04943366 0.17233233 0.40822652]
+ Performing replicate 23 / 200
+-[  0.0390993    1.05894713   4.14002099   9.36712507  17.47224873
+-  26.89336801]
+-[ 0.00122367  0.01087071  0.0266841   0.05049485  0.17834154  0.59493525]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04018128  1.06153561  4.09577817  9.26513979 17.09166103 26.01713156]
++[0.00125902 0.01082566 0.02643073 0.04909324 0.17731166 0.45066092]
+ Performing replicate 24 / 200
+-[  0.03864583   1.05714593   4.06372096   9.25449474  17.15422843
+-  25.97207072]
+-[ 0.00118399  0.01058439  0.02637373  0.04956499  0.177942    0.43099336]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03911189  1.04776702  4.12374546  9.22281215 17.14060401 26.52209084]
++[0.00116586 0.01073569 0.02658485 0.04904049 0.17745086 0.61378532]
+ Performing replicate 25 / 200
+-[  0.03948336   1.07547801   4.13191518   9.26925592  16.93290468
+-  26.06858333]
+-[ 0.001216    0.01101932  0.02574317  0.04979459  0.17438801  0.5499484 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04076984  1.05042164  4.12561296  9.19035734 17.03753787 26.3690878 ]
++[0.00124476 0.01110278 0.02505696 0.04895399 0.17827157 0.58499507]
+ Performing replicate 26 / 200
+-[  0.03809543   1.05961283   4.1290362    9.34039516  17.10617443
+-  25.64693642]
+-[ 0.00117995  0.01100063  0.02622283  0.04886901  0.17419206  0.45025915]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03898449  1.0546573   4.15180381  9.2626973  16.84376007 25.59697552]
++[0.00115487 0.01085495 0.02606065 0.04797529 0.17361287 0.46441599]
+ Performing replicate 27 / 200
+-[  0.03837429   1.06098132   4.13139397   9.23627861  16.98050859
+-  25.9840404 ]
+-[ 0.00116184  0.01099719  0.02600496  0.04870765  0.17490437  0.56004253]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03999522  1.09303557  4.10408993  9.29081769 17.14832343 26.00134637]
++[0.00120718 0.01082247 0.02600826 0.04983042 0.17559717 0.56912693]
+ Performing replicate 28 / 200
+-[  0.04089901   1.06094596   4.1084931    9.18954094  17.03366022
+-  27.19739676]
+-[  1.22335536e-03   1.09111714e-02   2.55241975e-02   4.91532731e-02
+-   1.79780353e-01   1.29700947e+00]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.02e-12
++[ 0.03940443  1.06044634  4.10938349  9.23038296 16.91251349 25.7359186 ]
++[0.00116005 0.01078888 0.02591056 0.04780177 0.17374039 0.70441365]
+ Performing replicate 29 / 200
+-[  0.03932373   1.06061798   4.14257651   9.25772679  17.1040141
+-  26.89166801]
+-[ 0.0012619   0.01106427  0.02624291  0.04818845  0.18052819  0.58651533]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.09e-12
++[ 0.04096845  1.04503172  4.09211164  9.29293921 17.12211553 26.24559952]
++[0.00123564 0.01064254 0.02565263 0.0497363  0.17688862 0.5317508 ]
+ Performing replicate 30 / 200
+-[  0.03830555   1.07675025   4.10593691   9.22379068  17.25475091
+-  27.46908558]
+-[ 0.00119107  0.01069722  0.02492837  0.04989302  0.18135647  1.18037019]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03895806  1.06483468  4.15005824  9.26166183 16.80550488 24.82327146]
++[0.00115856 0.01092314 0.02625955 0.04871588 0.16926657 0.38646173]
+ Performing replicate 31 / 200
+-[  0.04098643   1.07165904   4.13401233   9.23907172  16.76914282
+-  25.29474999]
+-[ 0.00123635  0.01066206  0.02597318  0.04915641  0.16994564  0.51959529]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04238008  1.05743743  4.1056308   9.32651482 16.92192634 25.39458344]
++[0.00127338 0.01089547 0.02630208 0.0496117  0.1706588  0.47758793]
+ Performing replicate 32 / 200
+-[  0.04214462   1.07084635   4.09901783   9.23740736  16.87358986
+-  25.83382194]
+-[ 0.00129874  0.01103236  0.02595043  0.04924991  0.17238572  0.65428254]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04159484  1.05071225  4.12666821  9.26660577 16.81424835 25.9618781 ]
++[0.00124964 0.01064769 0.02557691 0.05018687 0.17240914 0.66972394]
+ Performing replicate 33 / 200
+-[  0.04094335   1.07237575   4.10376286   9.19839308  16.89793352
+-  25.47194317]
+-[ 0.00128309  0.01119435  0.0261842   0.04887926  0.17367087  0.44363813]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04114856  1.08268687  4.12299115  9.24390106 16.85243354 25.35284803]
++[0.00126143 0.01082248 0.02576048 0.04938534 0.17348859 0.42136653]
+ Performing replicate 34 / 200
+-[  0.03943088   1.06345318   4.0892416    9.21663741  16.7218649
+-  25.38903272]
+-[ 0.00122541  0.01092207  0.02559204  0.0492007   0.17321738  0.45618271]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04116927  1.07259926  4.15824019  9.27528849 16.94791638 25.73293514]
++[0.00130898 0.01130228 0.02553292 0.04890238 0.17299947 0.59897261]
+ Performing replicate 35 / 200
+-[  0.04149619   1.08217791   4.08063046   9.20549221  16.74606988
+-  26.0494642 ]
+-[ 0.00125865  0.01093689  0.02551306  0.0487514   0.17804127  0.55025066]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.2e-12
++[ 0.03998254  1.06717449  4.14399697  9.23972496 16.9624028  26.96435759]
++[0.00121966 0.0108802  0.02620668 0.04891376 0.17943201 0.65080366]
+ Performing replicate 36 / 200
+-[  0.04155688   1.08030244   4.09280753   9.27662628  16.70768417
+-  26.03504328]
+-[ 0.00134798  0.01093258  0.02565731  0.04920167  0.17433314  0.62904366]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.04e-12
++[ 0.04264123  1.05767547  4.11653449  9.20769141 17.04500785 26.10842793]
++[0.00131076 0.01087422 0.02565996 0.04929654 0.17639253 0.52582893]
+ Performing replicate 37 / 200
+-[  0.03974489   1.07335977   4.08413552   9.25952372  17.29665173
+-  28.28563725]
+-[ 0.0011814   0.01110251  0.02563585  0.04962323  0.18547217  0.9038873 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04045021  1.06887039  4.11249878  9.23298414 17.00163821 26.54896778]
++[0.00121786 0.01088548 0.02588108 0.04842863 0.17858701 0.5923331 ]
+ Performing replicate 38 / 200
+-[  0.039329     1.08464059   4.10384123   9.24106683  16.80232203
+-  25.42109822]
+-[ 0.00119081  0.0110945   0.02596492  0.04873169  0.17260663  0.46046607]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03993204  1.05563989  4.13946936  9.17553932 16.98970347 25.99006797]
++[0.00121329 0.0107906  0.02626776 0.04774212 0.17667996 0.50637292]
+ Performing replicate 39 / 200
+-[  0.03920473   1.05686959   4.11568943   9.3071148   17.04466949
+-  25.61952895]
+-[ 0.00125859  0.01073203  0.02602774  0.04948098  0.1721275   0.55936092]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04086752  1.06424092  4.09857977  9.18226761 16.89390769 26.05426704]
++[0.00127276 0.01061977 0.02580727 0.04910851 0.17532733 0.6752216 ]
+ Performing replicate 40 / 200
+-[  0.04056849   1.04744608   4.10377396   9.31741397  16.84758713
+-  26.29780248]
+-[ 0.00123547  0.01095544  0.02572242  0.04949721  0.17546794  0.59808464]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04092222  1.05957368  4.12101868  9.20050245 16.89137484 25.83559166]
++[0.00131931 0.01091978 0.02611108 0.04812313 0.17558518 0.53834034]
+ Performing replicate 41 / 200
+-[  0.03906703   1.05905044   4.12239641   9.18702067  16.82501777
+-  27.10982459]
+-[ 0.00124812  0.01104048  0.0257842   0.04933316  0.17916364  0.73373553]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04151071  1.06513282  4.14839983  9.19586848 16.95203126 25.77890756]
++[0.00120184 0.01122049 0.02581584 0.04866411 0.17564218 0.48069513]
+ Performing replicate 42 / 200
+-[  0.0398643    1.0860701    4.10147125   9.24407548  16.61495954
+-  25.66198849]
+-[ 0.00121349  0.01086776  0.02609446  0.04894354  0.1697657   0.87173028]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.09e-12
++[ 0.03894117  1.06248328  4.10691162  9.237179   17.25767297 26.58383127]
++[0.00116467 0.01090227 0.02522051 0.04984708 0.17973117 0.57114519]
+ Performing replicate 43 / 200
+-[  0.04357665   1.05215961   4.10655597   9.17246431  17.33293253
+-  26.43350197]
+-[ 0.00132046  0.01078445  0.02569501  0.04937881  0.18181417  0.47190957]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.03893747  1.08998322  4.11294521  9.27011107 16.82152613 25.69162369]
++[0.00119889 0.01080592 0.02559094 0.04974843 0.173105   0.54165814]
+ Performing replicate 44 / 200
+-[  0.04005254   1.06836077   4.09590863   9.24323524  17.10990874
+-  26.00920421]
+-[ 0.00121285  0.0109505   0.02576628  0.04892032  0.17786524  0.43780567]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.09e-12
++[ 0.03969406  1.07588721  4.07855096  9.2164793  16.81727107 26.99420726]
++[0.00121327 0.0111927  0.02550437 0.04889684 0.17977323 0.75025091]
+ Performing replicate 45 / 200
+-[  0.04218812   1.05051556   4.08913382   9.29222086  16.94372273
+-  25.70293783]
+-[ 0.00134885  0.01094122  0.02527946  0.05010525  0.17262884  0.55128067]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.0409628   1.0498194   4.0570913   9.15863763 16.95732627 25.81274175]
++[0.0012538  0.01087767 0.02555359 0.04913447 0.17661516 0.47995671]
+ Performing replicate 46 / 200
+-[  0.03929456   1.06406797   4.10668074   9.28700209  16.95653585
+-  25.52549522]
+-[ 0.0011973   0.01118786  0.02571773  0.05017221  0.17154892  0.49591939]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03784128  1.05376079  4.14024376  9.20812591 16.99591019 27.63504139]
++[0.00118904 0.0109167  0.02527668 0.04916967 0.18216441 1.18168139]
+ Performing replicate 47 / 200
+-[  0.03858335   1.03859111   4.12398683   9.30506514  17.10646775
+-  26.93208427]
+-[ 0.00114838  0.01080016  0.02575895  0.04931567  0.17915994  0.67339173]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04072759  1.07355921  4.07755443  9.23753614 17.10142911 26.99060011]
++[0.00124392 0.01095825 0.02589432 0.04923171 0.17872629 0.76186565]
+ Performing replicate 48 / 200
+-[  0.04033213   1.07390753   4.11973596   9.23159698  16.91778576
+-  25.36657204]
+-[ 0.00119412  0.01101255  0.02606908  0.0485239   0.17345891  0.44675537]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04099168  1.07061333  4.05300409  9.31466777 17.07636877 26.11788757]
++[0.001288   0.01131441 0.02553209 0.04922798 0.17707894 0.46873487]
+ Performing replicate 49 / 200
+-[  0.03871061   1.05666491   4.12859303   9.20442253  16.96974794
+-  25.48725212]
+-[ 0.00114953  0.01109879  0.02532095  0.04958064  0.17279435  0.48974638]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.33e-12
++[ 0.04061109  1.0583099   4.1262091   9.32764957 16.77489422 24.89577443]
++[0.00121727 0.01087055 0.02613011 0.04908808 0.16753859 0.45652736]
+ Performing replicate 50 / 200
+-[  0.03817402   1.06825838   4.12405373   9.2687802   16.93024192
+-  25.60551154]
+-[ 0.00114902  0.011056    0.0253581   0.04956405  0.17307368  0.53240711]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03819336  1.04388309  4.06009309  9.23127245 16.83779946 26.03470382]
++[0.00115177 0.01070781 0.02585428 0.04860633 0.17578544 0.56278652]
+ Performing replicate 51 / 200
+-[  0.03962726   1.06215511   4.09561533   9.23442119  16.86799682
+-  26.40502022]
+-[ 0.0012121   0.01098618  0.0256175   0.04944702  0.17583399  0.77539775]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04296584  1.04995387  4.09454104  9.2908982  16.99548594 25.37116655]
++[0.00129242 0.01076949 0.02564604 0.04997884 0.17230372 0.43027189]
+ Performing replicate 52 / 200
+-[  0.03775153   1.08306049   4.08540509   9.22652442  16.96619078
+-  25.61464196]
+-[ 0.00113408  0.01121581  0.02503859  0.04921422  0.17451926  0.45703963]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04018633  1.05320304  4.10449686  9.32575202 16.94249606 25.35534363]
++[0.00122334 0.01101526 0.02538801 0.04877874 0.17110704 0.4582548 ]
+ Performing replicate 53 / 200
+-[  0.03809178   1.063273     4.1281617    9.27912326  17.07750772
+-  25.78878478]
+-[ 0.00112335  0.01085543  0.02552272  0.05002676  0.17362101  0.47762955]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.48e-12
++[ 0.04051422  1.07560024  4.06923639  9.23086576 16.99229678 25.27871149]
++[0.00122544 0.01100907 0.02547858 0.05014651 0.17030146 0.49117984]
+ Performing replicate 54 / 200
+-[  0.03988228   1.07086552   4.11554818   9.31917477  16.76564162
+-  25.47704926]
+-[ 0.00124647  0.01092716  0.02542296  0.0488907   0.17320091  0.44892903]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.6e-12
++[ 0.03992816  1.07733951  4.11835866  9.2895425  17.07267027 26.34914377]
++[0.00120233 0.01077134 0.02585971 0.0492027  0.17513452 0.64654949]
+ Performing replicate 55 / 200
+-[  0.03886668   1.04589804   4.15400504   9.18556453  16.92029095
+-  26.07227412]
+-[ 0.00118187  0.01084346  0.02535141  0.04877413  0.17799295  0.55600099]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.4e-12
++[ 0.04115035  1.06903961  4.13083836  9.25936527 17.15358012 26.20000776]
++[0.00126149 0.01120576 0.02621346 0.04973738 0.17704942 0.52284951]
+ Performing replicate 56 / 200
+-[  0.03940752   1.08780748   4.07378082   9.36011112  16.71736056
+-  26.09256179]
+-[ 0.00119906  0.01085569  0.02559264  0.04941776  0.17490801  0.55308288]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03685002  1.0741703   4.11392391  9.21633026 16.99122725 26.11778758]
++[0.00113625 0.01126669 0.02586411 0.04927455 0.17573413 0.52366967]
+ Performing replicate 57 / 200
+-[  0.03976834   1.05531585   4.12090988   9.25871227  17.05469332
+-  25.47384457]
+-[ 0.00116692  0.01091533  0.02545316  0.04961602  0.17314039  0.45619244]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03911325  1.06385719  4.10390873  9.24473572 16.97504659 25.88141365]
++[0.00114384 0.01096787 0.0257023  0.04927856 0.17515362 0.52197954]
+ Performing replicate 58 / 200
+-[  0.04022509   1.05304624   4.14279309   9.20411507  16.9114254
+-  25.23909446]
+-[ 0.00123073  0.01062749  0.02592157  0.04935883  0.17137561  0.4372685 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04016675  1.05762963  4.09604062  9.2954218  16.91930423 25.21394622]
++[0.00122563 0.01091803 0.02575721 0.04919718 0.17185306 0.41612643]
+ Performing replicate 59 / 200
+-[  0.04198442   1.09190931   4.1003484    9.24980997  17.09171136
+-  25.71404008]
+-[ 0.00126643  0.01104939  0.0254546   0.0495251   0.1747193   0.44425839]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 4.97e-13
++[ 0.0410047   1.05192772  4.09051153  9.24844476 17.07723005 26.33006755]
++[0.00126101 0.0109102  0.02573663 0.04979432 0.1765535  0.64089134]
+ Performing replicate 60 / 200
+-[  0.03836887   1.06013407   4.12801476   9.29639658  17.0862348
+-  25.97428981]
+-[ 0.00115669  0.01106848  0.02634074  0.04874742  0.17621757  0.47391828]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04018384  1.06779432  4.10814664  9.25829043 16.73288108 25.3879595 ]
++[0.00125703 0.0109299  0.02593901 0.04918681 0.17149163 0.51496746]
+ Performing replicate 61 / 200
+-[  0.04150982   1.04670208   4.07322963   9.25497209  17.02406772
+-  26.44909264]
+-[ 0.0012138   0.01079625  0.02563196  0.04881978  0.17865798  0.57299729]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 9.16e-13
++[ 0.03848274  1.06734914  4.07897815  9.17060981 16.76165313 25.57105989]
++[0.00120044 0.01092374 0.02553448 0.04871647 0.1718974  0.60931151]
+ Performing replicate 62 / 200
+-[  0.03934155   1.05389633   4.05520843   9.25180382  16.82299188
+-  25.96934134]
+-[ 0.00122482  0.01077927  0.02552698  0.04931858  0.17203859  0.72561108]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03944376  1.06983228  4.13510527  9.27047291 16.97492616 26.24980573]
++[0.00125554 0.01114837 0.02559724 0.04906641 0.17522364 0.68179652]
+ Performing replicate 63 / 200
+-[  0.0394505    1.06810984   4.14807615   9.26106136  17.14652708
+-  26.54316709]
+-[ 0.00119534  0.0110708   0.0262439   0.04923901  0.17967353  0.48537348]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04223143  1.0399216   4.07712503  9.24027004 17.05437249 26.10321778]
++[0.00129543 0.01061344 0.02517787 0.04975664 0.17730922 0.54984479]
+ Performing replicate 64 / 200
+-[  0.0386403    1.06666599   4.12295467   9.22205775  16.81061593
+-  25.49891838]
+-[ 0.00116541  0.01088585  0.02538442  0.04898985  0.17387773  0.4558854 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 4.44e-13
++[ 0.03684021  1.07295583  4.14277152  9.23300616 16.9725578  25.71754873]
++[0.00114692 0.01096672 0.0259681  0.04904269 0.17243528 0.60742236]
+ Performing replicate 65 / 200
+-[  0.03716103   1.06737994   4.10813167   9.2499215   17.1217963
+-  26.62964854]
+-[ 0.00118407  0.01068737  0.02567345  0.04938239  0.17844138  0.6512197 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.02e-12
++[ 0.03780477  1.07253211  4.08190003  9.26547105 16.86577347 26.38977367]
++[0.00114406 0.01087566 0.02554689 0.04917291 0.17410123 0.79437419]
+ Performing replicate 66 / 200
+-[  0.04031913   1.05198072   4.1507701    9.17412615  16.84593107
+-  26.14885276]
+-[ 0.0013035   0.01093227  0.02562355  0.04907074  0.17765979  0.5370083 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.0401197   1.06244674  4.06151461  9.2801348  16.99890142 25.43138518]
++[0.00118019 0.01108739 0.02592773 0.04945637 0.17213388 0.45842425]
+ Performing replicate 67 / 200
+-[  0.03923131   1.06769487   4.10739247   9.27047662  16.59407627
+-  25.41735903]
+-[ 0.00118793  0.01106223  0.02600184  0.0487558   0.17095783  0.55762204]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03747782  1.0521345   4.11481637  9.24637551 16.90047345 25.7987785 ]
++[0.00113409 0.01082343 0.02623638 0.04860003 0.1751291  0.51218015]
+ Performing replicate 68 / 200
+-[  0.03867774   1.05728148   4.13095151   9.31766963  17.1178145
+-  25.38953995]
+-[ 0.00116589  0.01076585  0.02561717  0.04914847  0.17286508  0.39079478]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04066381  1.06937607  4.08621831  9.30465603 17.11315295 27.01104886]
++[0.00119873 0.01084634 0.02528301 0.04934373 0.18104588 0.58261039]
+ Performing replicate 69 / 200
+-[  0.03988349   1.05983514   4.13566499   9.22941366  16.73269908
+-  25.64926831]
+-[ 0.00120628  0.01064541  0.02615612  0.04820797  0.17394324  0.5293269 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04045144  1.08188797  4.0943604   9.24750022 16.98975397 26.21395278]
++[0.00125666 0.01105172 0.02650129 0.04884713 0.17232104 0.87316908]
+ Performing replicate 70 / 200
+-[  0.03933935   1.05549177   4.11624344   9.2629141   16.86525097
+-  25.08007774]
+-[ 0.00118636  0.01115085  0.0259921   0.04963559  0.16991464  0.45969049]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.03870965  1.07632687  4.10441094  9.28654289 16.68615709 25.32723236]
++[0.00119717 0.01119132 0.025579   0.04920554 0.17011347 0.49316719]
+ Performing replicate 71 / 200
+-[  0.03882391   1.06580309   4.11033449   9.27573771  16.97549046
+-  24.96251834]
+-[ 0.00121027  0.01088758  0.02607206  0.04916825  0.17026025  0.40913918]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.039386    1.06092591  4.09698883  9.27454209 16.74268043 25.81112868]
++[0.00126535 0.01070808 0.02500017 0.04951477 0.17237893 0.63573176]
+ Performing replicate 72 / 200
+-[  0.0409446    1.05733141   4.07181996   9.37976135  17.03248256
+-  26.91117293]
+-[ 0.00125731  0.01059108  0.02552714  0.05026152  0.17300802  1.19786023]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04041988  1.07607761  4.13212894  9.24934236 17.27963073 27.03782815]
++[0.00127993 0.01089502 0.02562989 0.04922584 0.1818504  0.59927437]
+ Performing replicate 73 / 200
+-[  0.03811781   1.06789553   4.11516307   9.32446679  17.43640884
+-  26.61405269]
+-[ 0.00116659  0.01094016  0.02570927  0.05062876  0.17742682  0.65746405]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04127929  1.06025579  4.12813558  9.26820445 17.21134527 26.47929213]
++[0.00129223 0.01107509 0.02544493 0.05007894 0.17567822 0.68876105]
+ Performing replicate 74 / 200
+-[  0.0381458    1.05887914   4.09796857   9.30892834  16.88784495
+-  25.71487556]
+-[ 0.00112839  0.01085114  0.02572465  0.05028719  0.17065214  0.82761706]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04004994  1.0618723   4.11166654  9.29885398 16.7933635  25.44362532]
++[0.00125764 0.01066891 0.02633063 0.04917732 0.17081283 0.52717857]
+ Performing replicate 75 / 200
+-[  0.0401521    1.06236363   4.11017279   9.35329751  17.26570635
+-  25.60108332]
+-[ 0.00120785  0.01071492  0.02592803  0.05015632  0.17163907  0.46673607]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04024531  1.05842191  4.06520495  9.29120638 16.89498188 25.3585223 ]
++[0.00121932 0.01109536 0.02543826 0.04984881 0.17390731 0.38379606]
+ Performing replicate 76 / 200
+-[  0.04208477   1.07481956   4.08766469   9.21995234  17.04520851
+-  26.23069767]
+-[ 0.00128655  0.01111018  0.02506267  0.0485317   0.17912092  0.46343036]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03990177  1.07198513  4.15316475  9.21020854 16.78139041 25.12109985]
++[0.00121383 0.01109648 0.0260966  0.04841383 0.17080527 0.44464204]
+ Performing replicate 77 / 200
+-[  0.04039995   1.06145861   4.13692693   9.25592441  16.80346774
+-  25.68093991]
+-[ 0.0012299   0.01062708  0.02570854  0.04899283  0.17400377  0.47454473]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03962819  1.07465776  4.06810035  9.18361782 16.87836588 26.08562736]
++[0.00115638 0.0112079  0.02514235 0.04962527 0.17354188 0.72858282]
+ Performing replicate 78 / 200
+-[  0.03910017   1.0564547    4.13071047   9.29914633  16.81259322
+-  24.58244981]
+-[ 0.00116647  0.01073716  0.02630342  0.04940024  0.16571311  0.44709115]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04020658  1.05935004  4.08847299  9.21219507 17.00925361 25.78227613]
++[0.00121536 0.01105801 0.02554771 0.0491247  0.17645846 0.47837605]
+ Performing replicate 79 / 200
+-[  0.04034019   1.06444659   4.09987915   9.25370012  16.89709345
+-  25.84146065]
+-[ 0.00120831  0.0109684   0.02552749  0.04958401  0.17512119  0.47899182]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03901763  1.07325807  4.10546415  9.18539543 17.24835558 26.12799148]
++[0.00121656 0.01102838 0.02539859 0.04954287 0.17725647 0.63038033]
+ Performing replicate 80 / 200
+-[  0.03983444   1.07391485   4.11666155   9.22797895  16.90323485
+-  26.33098555]
+-[ 0.00122238  0.01078531  0.02588733  0.049162    0.17522583  0.65654687]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03772282  1.05135637  4.12105194  9.25839731 16.88947632 26.02692276]
++[0.00111679 0.01074593 0.02571016 0.04870125 0.1744918  0.55717131]
+ Performing replicate 81 / 200
+-[  0.03970533   1.06197558   4.11074636   9.19174751  17.07448554
+-  26.01918528]
+-[ 0.00121541  0.01084445  0.02529696  0.04798404  0.17642051  0.58650156]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04113095  1.07498998  4.13351432  9.29589947 17.24507685 25.69092776]
++[0.00126642 0.01098841 0.02603217 0.04910939 0.17458546 0.45797298]
+ Performing replicate 82 / 200
+-[  0.03677122   1.06105984   4.11488616   9.23809298  16.73061564
+-  25.71098515]
+-[ 0.00112503  0.01078944  0.02585207  0.04903198  0.17322011  0.5000389 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04029865  1.05870641  4.12277071  9.2852909  16.90164222 25.80287098]
++[0.0012529  0.01098668 0.02586294 0.04893893 0.17566426 0.45041842]
+ Performing replicate 83 / 200
+-[  0.04107467   1.0653355    4.13172002   9.25239326  17.01280283
+-  26.27385885]
+-[ 0.00121333  0.01112249  0.02577792  0.04912166  0.17699378  0.54697921]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04064571  1.06262115  4.13519108  9.21648576 17.07434298 26.4193471 ]
++[0.00127865 0.01086618 0.0260134  0.04779824 0.17970389 0.53661174]
+ Performing replicate 84 / 200
+-[  0.03845724   1.05619663   4.10560125   9.25294263  17.11784669
+-  26.88939422]
+-[ 0.00112274  0.01061671  0.02623139  0.04863759  0.17992137  0.74058104]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.04e-12
++[ 0.04075934  1.07784213  4.12345256  9.3411892  16.86490949 25.2841445 ]
++[0.00127673 0.01084731 0.02537164 0.04981869 0.17003347 0.52723186]
+ Performing replicate 85 / 200
+-[  0.03986881   1.05518542   4.12486834   9.25122772  16.89936544
+-  25.57645412]
+-[ 0.00130498  0.01089083  0.02541555  0.04986187  0.17140671  0.57647852]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03797752  1.06345571  4.12669393  9.25996554 17.1828226  26.16356859]
++[0.00116438 0.01103706 0.0256936  0.04924531 0.17782879 0.50250589]
+ Performing replicate 86 / 200
+-[  0.04232009   1.0540681    4.08796043   9.34980818  17.1081857
+-  26.46320241]
+-[ 0.00126153  0.01083321  0.02542775  0.04979714  0.17760273  0.76258026]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04049187  1.06699882  4.12169282  9.18043815 17.0033469  26.73044448]
++[0.00127624 0.01112024 0.02556946 0.04882608 0.18120119 0.56101813]
+ Performing replicate 87 / 200
+-[  0.03948211   1.05328782   4.12304039   9.19464567  16.9815505
+-  26.28691147]
+-[ 0.00119577  0.01061199  0.02565895  0.04943264  0.17746581  0.58841538]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.29e-12
++[ 0.0377928   1.05184561  4.13376216  9.31883317 17.32670932 26.16292849]
++[0.0011722  0.01088862 0.02623937 0.04991815 0.17661542 0.52676727]
+ Performing replicate 88 / 200
+-[  0.03791471   1.06078185   4.12339037   9.29977958  17.15756274
+-  25.90687533]
+-[ 0.0011291   0.01123224  0.0259291   0.04924572  0.17453538  0.48963679]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.03771418  1.07214751  4.13077042  9.24600658 17.01166339 26.60593503]
++[0.00117547 0.01123351 0.02609129 0.04839887 0.17481887 0.92303418]
+ Performing replicate 89 / 200
+-[  0.04087765   1.0605252    4.12449644   9.29654138  16.9609525
+-  25.24359057]
+-[ 0.00121727  0.01133554  0.02545894  0.05002876  0.17198602  0.36917528]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04090549  1.05584047  4.15149472  9.21704926 16.64378726 25.21268171]
++[0.00122963 0.01100725 0.02582475 0.04917159 0.17128015 0.46514184]
+ Performing replicate 90 / 200
+-[  0.03983795   1.04901499   4.08310429   9.31075973  16.93125085
+-  25.88421139]
+-[ 0.00120117  0.01086426  0.02603724  0.04904788  0.17449422  0.47714371]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03985388  1.07908627  4.09697946  9.18453296 16.98945641 26.72844428]
++[0.00121978 0.01107567 0.02523913 0.04934788 0.17722961 0.78307547]
+ Performing replicate 91 / 200
+-[  0.03896253   1.05143522   4.11418666   9.33723489  17.06327832
+-  25.48520278]
+-[ 0.00122054  0.01081596  0.0258668   0.05007231  0.17214854  0.46851934]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03803466  1.03544304  4.08860532  9.23777155 17.05713549 25.58193499]
++[0.00115501 0.01076071 0.02497495 0.04967383 0.17374451 0.4872352 ]
+ Performing replicate 92 / 200
+-[  0.04101405   1.048906     4.12878765   9.19697868  16.80726944
+-  25.70100635]
+-[ 0.00126021  0.01064219  0.02535777  0.05032234  0.17214338  0.64169694]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 9.16e-13
++[ 0.04006347  1.04753573  4.14574212  9.23344396 17.48139416 26.61847895]
++[0.00122157 0.01102464 0.02648074 0.04905509 0.18128044 0.468383  ]
+ Performing replicate 93 / 200
+-[  0.03826325   1.04682516   4.13189649   9.30472316  16.77310672
+-  25.9488829 ]
+-[ 0.00115417  0.01098602  0.02581776  0.04954723  0.1732355   0.57264166]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.03872923  1.05476097  4.06366533  9.24674771 16.83094137 25.59076482]
++[0.00115099 0.01058947 0.02547795 0.04870884 0.17438749 0.50809601]
+ Performing replicate 94 / 200
+-[  0.04008388   1.05568891   4.15699522   9.23955533  16.75516876
+-  25.43538515]
+-[ 0.00122172  0.01067529  0.02578736  0.04793826  0.17152036  0.61978994]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.72e-12
++[ 0.04261512  1.0710742   4.06930434  9.14893023 16.56455583 24.98794174]
++[0.00133729 0.01129983 0.02499118 0.04830273 0.1721445  0.39420417]
+ Performing replicate 95 / 200
+-[  0.03989147   1.06057191   4.12602383   9.28020459  17.1171829
+-  26.9770861 ]
+-[ 0.00121633  0.01089386  0.02586022  0.04962115  0.17986809  0.60045646]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04111475  1.04710012  4.08189777  9.26389806 17.18444428 26.24120363]
++[0.00128206 0.01096107 0.02530173 0.04955747 0.17587679 0.55822492]
+ Performing replicate 96 / 200
+-[  0.04018372   1.06378407   4.09540792   9.28942704  17.15932367
+-  26.73308559]
+-[ 0.0012441   0.01076856  0.02576526  0.0498375   0.17894144  0.62273269]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.0394957   1.06438775  4.08469906  9.27085151 17.17478418 26.32068726]
++[0.00122771 0.01057243 0.02531828 0.04920897 0.17793623 0.5146069 ]
+ Performing replicate 97 / 200
+-[  0.04100587   1.06522803   4.13572988   9.22937296  17.25872487
+-  26.82197994]
+-[ 0.00123723  0.01083285  0.02551154  0.04993346  0.17862635  0.78778591]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03921839  1.06520555  4.11028003  9.25724806 17.09487629 26.51208104]
++[0.00118925 0.0105599  0.02588019 0.04949867 0.17707493 0.66313222]
+ Performing replicate 98 / 200
+-[  0.04067516   1.08158748   4.13823673   9.23741068  16.9811306
+-  25.23987472]
+-[ 0.00123256  0.01105371  0.02533448  0.04867907  0.17237308  0.40975343]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.02e-12
++[ 0.04032752  1.07070478  4.07819303  9.28741418 16.98281547 26.02644847]
++[0.00123312 0.01113446 0.02577189 0.05048048 0.17371148 0.62760602]
+ Performing replicate 99 / 200
+-[  0.04062395   1.05988377   4.12728124   9.27860033  16.58976787
+-  25.02622718]
+-[ 0.00125277  0.01090675  0.02603776  0.04873989  0.16872912  0.47892528]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04137904  1.07148857  4.10642452  9.25845353 16.83459289 25.26143481]
++[0.00129265 0.01085527 0.02629242 0.04884718 0.17024108 0.56396339]
+ Performing replicate 100 / 200
+-[  0.03972257   1.09509281   4.15950308   9.30395591  17.09624035
+-  25.84577678]
+-[ 0.00126001  0.01084742  0.02559193  0.04980253  0.17180177  0.61705271]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04080261  1.06565138  4.14621308  9.23741143 16.80942848 25.56848149]
++[0.00119377 0.01106742 0.02596423 0.04853808 0.17287324 0.53779613]
+ Performing replicate 101 / 200
+-[  0.04056107   1.06268142   4.14299783   9.27897378  17.25811858
+-  26.43393499]
+-[ 0.00126907  0.01101612  0.02539773  0.049318    0.17830433  0.52030066]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03978013  1.05607595  4.13311754  9.25369428 16.87968506 26.53965032]
++[0.00122858 0.01101825 0.02562545 0.04959701 0.17755548 0.75236531]
+ Performing replicate 102 / 200
+-[  0.03971916   1.06481619   4.1697053    9.19906996  16.8642742
+-  24.95901197]
+-[ 0.00123067  0.01087849  0.02553632  0.04840275  0.17076318  0.42680896]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03974699  1.05780552  4.13175776  9.29190721 16.64104573 24.70888587]
++[0.00124861 0.01093375 0.0258383  0.04935298 0.16661574 0.46024764]
+ Performing replicate 103 / 200
+-[  0.04019079   1.06933399   4.1502625    9.31834996  16.85776306
+-  25.29384044]
+-[ 0.00121923  0.01105588  0.02564125  0.04967859  0.16801638  0.58912949]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03855655  1.05026406  4.11644115  9.29256212 16.80431068 25.31318868]
++[0.00117736 0.01065185 0.02648942 0.04880783 0.16993571 0.74053195]
+ Performing replicate 104 / 200
+-[  0.04044161   1.07193778   4.12030397   9.23031517  17.0894128
+-  25.77459379]
+-[ 0.00119144  0.01091753  0.02562534  0.05004625  0.17423257  0.4822451 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03957732  1.07284817  4.09490115  9.1343354  16.80342512 25.11514265]
++[0.00119039 0.01111583 0.02534771 0.04973067 0.17169597 0.45651428]
+ Performing replicate 105 / 200
+-[  0.03966612   1.04732655   4.10900437   9.21560935  16.97641103
+-  25.28823359]
+-[ 0.00113239  0.01083073  0.02572284  0.04849648  0.17266307  0.41216901]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04067764  1.05440673  4.0901626   9.23276269 16.79637418 25.97455848]
++[0.00124436 0.01107529 0.02623409 0.04803925 0.17574689 0.56412655]
+ Performing replicate 106 / 200
+-[  0.04058305   1.06194868   4.13960165   9.28330548  16.99237878
+-  26.02023238]
+-[ 0.00121885  0.01099261  0.02627706  0.04942447  0.1745773   0.59194044]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03898233  1.04732805  4.11130212  9.32657383 17.1688408  26.28303926]
++[0.00117093 0.01111487 0.02547272 0.04927551 0.17686225 0.49228761]
+ Performing replicate 107 / 200
+-[  0.04016653   1.0586404    4.12374235   9.16855927  16.97353355
+-  25.99918498]
+-[ 0.00125259  0.01097261  0.02556163  0.04937959  0.17768187  0.45470523]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03955718  1.06472468  4.11938321  9.23990651 16.87385903 26.43387135]
++[0.00122283 0.01093417 0.02589904 0.04935481 0.17792168 0.62450403]
+ Performing replicate 108 / 200
+-[  0.03879013   1.06590004   4.14027896   9.24574505  17.14800199
+-  25.70161487]
+-[ 0.00121531  0.01092094  0.02568198  0.04976532  0.17439807  0.42686539]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.51e-12
++[ 0.03969704  1.05198413  4.09605366  9.28220511 16.96117849 25.93311487]
++[0.00121722 0.0107081  0.02611258 0.04877787 0.1751717  0.52120009]
+ Performing replicate 109 / 200
+-[  0.03920765   1.05489571   4.10904223   9.21155769  17.07863938
+-  26.96082993]
+-[ 0.0012491   0.01076601  0.02613833  0.04872695  0.18377979  0.50876926]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04070641  1.06283547  4.0917313   9.24848488 17.06413444 26.05554485]
++[0.00123605 0.01111822 0.02584615 0.0495416  0.17681684 0.48197416]
+ Performing replicate 110 / 200
+-[  0.03783798   1.06178244   4.07315509   9.26740031  17.01632652
+-  26.76811196]
+-[ 0.00114821  0.0109043   0.02578434  0.04800786  0.18239618  0.5642425 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.09e-12
++[ 0.04067367  1.05260032  4.07163454  9.22974058 16.85616976 25.21889182]
++[0.00125346 0.0105616  0.02612463 0.04934689 0.17127147 0.46938113]
+ Performing replicate 111 / 200
+-[  0.04113307   1.06937907   4.10844611   9.21849545  16.98213462
+-  27.69583133]
+-[ 0.00127659  0.01073172  0.02569224  0.04941777  0.18081823  1.10021637]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04035482  1.04090992  4.08679139  9.23546774 17.25817909 26.14352913]
++[0.0012295  0.01070532 0.02594349 0.04961055 0.17741344 0.54740953]
+ Performing replicate 112 / 200
+-[  0.0378916    1.06092494   4.12751179   9.2131647   16.72047501
+-  25.73117883]
+-[ 0.00117006  0.01091807  0.0254063   0.04844317  0.17340027  0.59354293]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 4.97e-13
++[ 0.03851721  1.06374754  4.12898974  9.22815738 17.32625948 27.13681444]
++[0.00117103 0.01088856 0.02546227 0.04930057 0.18009885 0.86785184]
+ Performing replicate 113 / 200
+-[  0.03879842   1.05923812   4.15028344   9.24604497  17.1040684
+-  25.89964035]
+-[ 0.00119105  0.01113864  0.02577114  0.04985394  0.17423649  0.55067381]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03975256  1.07684118  4.17131174  9.25676741 17.33894298 26.49662909]
++[0.0012304  0.01111145 0.02604939 0.0496227  0.17781969 0.53898784]
+ Performing replicate 114 / 200
+-[  0.03986741   1.04559998   4.09840359   9.20590113  17.03039231
+-  26.27680404]
+-[ 0.00125042  0.0108496   0.02578333  0.04871789  0.17753269  0.53927288]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03933926  1.06547972  4.11104166  9.2645009  17.06956076 25.30489389]
++[0.00121352 0.01117126 0.02570488 0.04891444 0.17389792 0.37255527]
+ Performing replicate 115 / 200
+-[  0.03796941   1.07580756   4.0914414    9.22499807  17.18948799
+-  25.9507876 ]
+-[ 0.00116507  0.01095556  0.02533575  0.05007476  0.17712813  0.44888495]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04082175  1.06947184  4.11489152  9.23544977 17.0222807  26.73544549]
++[0.00125021 0.01106241 0.02574139 0.0492689  0.1801875  0.60605367]
+ Performing replicate 116 / 200
+-[  0.04138133   1.04793324   4.10421298   9.34562954  17.40152011
+-  26.0026261 ]
+-[ 0.00128974  0.01086486  0.02601164  0.04981699  0.17563692  0.47490909]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03969111  1.05697663  4.13590081  9.23563459 16.689505   24.89829   ]
++[0.0012505  0.01073039 0.0257756  0.04798925 0.16868445 0.48805263]
+ Performing replicate 117 / 200
+-[  0.04028955   1.07236332   4.14659559   9.31715083  17.03785533
+-  26.28553595]
+-[ 0.00128571  0.0110412   0.0256319   0.04930334  0.17644276  0.60921994]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03899082  1.06118654  4.16664215  9.19085736 17.21477983 25.81952023]
++[0.0012246  0.01059931 0.02584278 0.04872755 0.17608251 0.4701872 ]
+ Performing replicate 118 / 200
+-[  0.0404798    1.0413664    4.11790418   9.26735945  17.34113028
+-  25.83928645]
+-[ 0.00120244  0.01088345  0.02606468  0.04985296  0.17584872  0.46738874]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03938932  1.04182525  4.13906231  9.22861148 16.73108122 25.82951928]
++[0.00122267 0.01074873 0.02551924 0.04798966 0.17680297 0.46121468]
+ Performing replicate 119 / 200
+-[  0.04130042   1.07092674   4.10352487   9.23831951  17.17766571
+-  25.96775538]
+-[ 0.00125836  0.01078906  0.02601971  0.04969393  0.17471911  0.58320999]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04085653  1.08523539  4.10752553  9.29106241 17.12397354 26.45965902]
++[0.00126275 0.01095167 0.02614668 0.04909208 0.17891643 0.57904427]
+ Performing replicate 120 / 200
+-[  0.03989094   1.06972924   4.13119807   9.22439206  17.34792591
+-  26.65192436]
+-[ 0.00124709  0.0109513   0.02583579  0.04970208  0.1816552   0.51888228]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03966784  1.05275393  4.06334652  9.24052813 16.96513471 26.0018254 ]
++[0.00125752 0.0109406  0.02580093 0.04954974 0.17610202 0.52701718]
+ Performing replicate 121 / 200
+-[  0.03886831   1.05644038   4.16189491   9.27478227  17.05671415
+-  26.03793544]
+-[ 0.0012069   0.01064922  0.02641444  0.04861642  0.17618984  0.570946  ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.0392278   1.0509059   4.14813816  9.27401765 16.95575595 25.65411279]
++[0.00124328 0.01095879 0.02579234 0.04980574 0.17335403 0.45269733]
+ Performing replicate 122 / 200
+-[  0.03845955   1.0692065    4.04336601   9.153531    16.97012872
+-  26.07238461]
+-[ 0.00116889  0.01083338  0.02494681  0.04991075  0.1785819   0.47401595]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.49e-12
++[ 0.04030122  1.06736746  4.10581422  9.27326187 17.22882853 26.23765112]
++[0.00128936 0.0108582  0.02544977 0.04997193 0.17704064 0.53586202]
+ Performing replicate 123 / 200
+-[  0.04156581   1.07785273   4.11470621   9.35139327  17.10678998
+-  26.07432017]
+-[ 0.00127914  0.01081712  0.02541242  0.05101825  0.17360648  0.53747748]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04098913  1.07027915  4.1308825   9.17640299 16.59387907 25.29020727]
++[0.00126063 0.01104441 0.02555134 0.04796448 0.17176697 0.4881096 ]
+ Performing replicate 124 / 200
+-[  0.0369523    1.06708374   4.09793758   9.2176403   17.17170717
+-  27.35039341]
+-[  1.12591222e-03   1.09168894e-02   2.56230242e-02   4.98695112e-02
+-   1.78652167e-01   1.13871906e+00]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04062636  1.0738277   4.11539359  9.23544782 17.06929376 26.60251332]
++[0.00132629 0.01075991 0.0261117  0.0489554  0.18072907 0.52337566]
+ Performing replicate 125 / 200
+-[  0.03916859   1.05790806   4.0774769    9.22638289  17.1919002
+-  26.92773245]
+-[ 0.00118327  0.01092405  0.02567421  0.04908701  0.18286606  0.54396684]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.03937951  1.04991478  4.07657551  9.37451092 17.30034472 26.67726699]
++[0.00124574 0.01077056 0.02617023 0.05046814 0.1755068  0.6622275 ]
+ Performing replicate 126 / 200
+-[  0.03977586   1.04991045   4.148005     9.22468179  17.06792636
+-  26.30053771]
+-[ 0.0012626   0.01095323  0.02563349  0.04980977  0.17653974  0.67672793]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04014618  1.06962094  4.13476275  9.27207376 17.01697019 25.94857751]
++[0.00122715 0.01086642 0.02608751 0.0490112  0.17526211 0.59631582]
+ Performing replicate 127 / 200
+-[  0.04142095   1.0559735    4.12704262   9.23582     16.8061218
+-  25.95989429]
+-[ 0.00125754  0.01098718  0.02571506  0.04887964  0.17428845  0.55912737]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.84e-12
++[ 0.04012365  1.06959893  4.136795    9.30053741 16.81646147 25.59531474]
++[0.00120238 0.01066103 0.02626163 0.0496726  0.17102142 0.49455065]
+ Performing replicate 128 / 200
+-[  0.03719678   1.04752747   4.18203517   9.23396859  17.0634186
+-  26.32968929]
+-[ 0.001157    0.01071383  0.02630357  0.04895444  0.17690081  0.60939269]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03907917  1.06535349  4.09006646  9.29775737 16.98873287 25.94891514]
++[0.0012042  0.0109542  0.02565464 0.04945527 0.17557739 0.496429  ]
+ Performing replicate 129 / 200
+-[  0.04199611   1.06797827   4.15426835   9.19160114  16.91904166
+-  25.57800039]
+-[ 0.00127048  0.01105406  0.02589197  0.04924891  0.1746844   0.44325957]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04007009  1.0665576   4.09885144  9.26820275 16.97261825 25.51556333]
++[0.00122057 0.01089746 0.02572118 0.04924192 0.17384807 0.41869537]
+ Performing replicate 130 / 200
+-[  0.03810507   1.06550056   4.10015959   9.2487155   17.11834377
+-  25.96126425]
+-[ 0.0011702   0.01135679  0.02531197  0.04916234  0.17644098  0.48780892]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03940556  1.06150568  4.124533    9.30757003 16.92021228 26.12372054]
++[0.00120674 0.01093973 0.02615613 0.04808091 0.17450865 0.63318736]
+ Performing replicate 131 / 200
+-[  0.03925455   1.04888968   4.09475578   9.25740188  16.76167382
+-  25.37098742]
+-[ 0.00120104  0.01103548  0.02540658  0.04888858  0.17244616  0.51280446]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03920296  1.08025181  4.10822698  9.27723336 17.24483201 25.98370511]
++[0.00123939 0.01104459 0.02560428 0.04956373 0.17458978 0.58584147]
+ Performing replicate 132 / 200
+-[  0.03922079   1.06169897   4.12579203   9.17781116  17.01796859
+-  25.45095861]
+-[ 0.00118245  0.01100145  0.02540074  0.049855    0.17311313  0.46057395]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03858646  1.07799773  4.13255904  9.27317447 16.95468385 25.56091087]
++[0.00119266 0.01101825 0.02589311 0.04927594 0.17201834 0.54546328]
+ Performing replicate 133 / 200
+-[  0.03952071   1.06816464   4.08847207   9.30036398  17.15135567
+-  26.31653997]
+-[ 0.0011987   0.01096494  0.02614188  0.04864399  0.17963335  0.492792  ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03911504  1.06471426  4.07818217  9.29121857 17.32718995 27.10973772]
++[0.00122737 0.01112691 0.02537415 0.05077511 0.18009441 0.64181253]
+ Performing replicate 134 / 200
+-[  0.04166397   1.05488153   4.05895388   9.19203898  17.18184885
+-  26.77963559]
+-[ 0.00123061  0.01086966  0.02528654  0.05017073  0.18146952  0.52727654]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03993939  1.06159119  4.15834172  9.32156648 17.15021594 27.34403775]
++[0.00124575 0.01097182 0.02620751 0.04838349 0.18149691 0.70304715]
+ Performing replicate 135 / 200
+-[  0.04136422   1.06096963   4.11123148   9.20663531  16.67375264
+-  25.52112358]
+-[ 0.00127832  0.01088189  0.02545053  0.04918635  0.17224972  0.53498091]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03997742  1.04670652  4.10441351  9.24844055 16.88659783 25.57793852]
++[0.0012007  0.01062593 0.02601795 0.04978437 0.1709323  0.50156911]
+ Performing replicate 136 / 200
+-[  0.04219685   1.04388749   4.12758996   9.2469164   17.27460208
+-  27.39583162]
+-[ 0.00127735  0.01075889  0.02578018  0.04891266  0.18656228  0.51596832]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04227092  1.07948184  4.08094232  9.24616593 17.18148586 26.50789515]
++[0.00130684 0.01104017 0.02546124 0.04986266 0.17654614 0.72951383]
+ Performing replicate 137 / 200
+-[  0.03985634   1.06269733   4.11189872   9.25424476  17.21081873
+-  26.19167471]
+-[ 0.00121413  0.01106653  0.02546953  0.04982476  0.17848555  0.44741422]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04186856  1.05911993  4.08421965  9.22783168 17.20832579 27.54204858]
++[0.00126092 0.01083188 0.02558903 0.0498912  0.18237663 0.80552724]
+ Performing replicate 138 / 200
+-[  0.04013466   1.06941419   4.08422282   9.16676778  16.99451755
+-  26.30783196]
+-[ 0.00119747  0.01102637  0.02567901  0.04936201  0.17694132  0.66087289]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.31e-12
++[ 0.03830127  1.05652294  4.09234818  9.26098698 17.06382018 26.35469625]
++[0.00113282 0.01088066 0.02521804 0.04924227 0.17654489 0.55652125]
+ Performing replicate 139 / 200
+-[  0.03878843   1.06913422   4.07804802   9.27823834  17.10329262
+-  25.88496333]
+-[ 0.00118057  0.01080404  0.02634294  0.04955651  0.17520674  0.48367742]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03931839  1.05496684  4.11669925  9.28456829 16.91975186 25.78198815]
++[0.00117346 0.01066347 0.02586121 0.04907783 0.17525836 0.45948119]
+ Performing replicate 140 / 200
+-[  0.04010342   1.06048116   4.16675989   9.26194476  16.81398259
+-  25.07159596]
+-[ 0.00123591  0.01077064  0.02539761  0.04958305  0.1690769   0.49305708]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03889085  1.05844308  4.10712845  9.21635591 17.19083339 26.03355946]
++[0.00122652 0.01071796 0.02597344 0.04941993 0.1767484  0.55869732]
+ Performing replicate 141 / 200
+-[  0.03874465   1.05328165   4.0431712    9.27195769  16.99390768
+-  25.6237777 ]
+-[ 0.00116937  0.01065705  0.02579101  0.0484069   0.17646992  0.40229584]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03899333  1.05838529  4.10508641  9.20548026 16.95892104 26.60010583]
++[0.00120943 0.01082774 0.02536828 0.049502   0.17858898 0.62024083]
+ Performing replicate 142 / 200
+-[  0.04215721   1.07142533   4.0808735    9.32323629  17.04227769
+-  25.17598607]
+-[ 0.00127759  0.01080358  0.02566303  0.05021267  0.17035356  0.4006108 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03876535  1.07044924  4.10229425  9.25400499 17.29433168 26.3273031 ]
++[0.00117899 0.01090084 0.02487081 0.05012054 0.17807981 0.51088585]
+ Performing replicate 143 / 200
+-[  0.04043168   1.07069117   4.10204078   9.29240237  17.14369459
+-  26.04797286]
+-[ 0.00120949  0.01053949  0.02594493  0.04934239  0.17456359  0.66125308]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.03965197  1.07068087  4.07476155  9.28150572 16.96241989 25.56316921]
++[0.0012036  0.01108448 0.02594581 0.04986659 0.17247068 0.51616133]
+ Performing replicate 144 / 200
+-[  0.04088449   1.05318877   4.08067794   9.18244357  16.977117
+-  25.95323729]
+-[ 0.00129047  0.01072145  0.02522834  0.04993846  0.17707853  0.45108695]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03782186  1.04819365  4.08654462  9.19758351 17.08139035 26.73805951]
++[0.00123128 0.01076974 0.02528505 0.04940238 0.17878989 0.75919779]
+ Performing replicate 145 / 200
+-[  0.04009235   1.06843982   4.09262506   9.2638655   17.31553256
+-  26.89565361]
+-[ 0.00127346  0.01123077  0.02565637  0.04922175  0.18174126  0.61998037]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.59e-12
++[ 0.03955792  1.06748669  4.12274755  9.2876324  16.84191376 25.88427357]
++[0.00122025 0.01097262 0.02566806 0.04836106 0.17422019 0.51345935]
+ Performing replicate 146 / 200
+-[  0.03963124   1.07956863   4.13765331   9.20350867  17.16504076
+-  25.86232222]
+-[ 0.00114865  0.0109487   0.02540278  0.04911431  0.17617338  0.43291386]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.73e-12
++[ 0.04090624  1.07061657  4.12248787  9.22129461 17.13767388 25.7251652 ]
++[0.00124265 0.01090442 0.02619221 0.04934468 0.17545381 0.4455065 ]
+ Performing replicate 147 / 200
+-[  0.03985924   1.04159808   4.08316946   9.3056996   16.75991648
+-  26.11941344]
+-[ 0.00122513  0.01096303  0.0262326   0.04886815  0.17401069  0.78336073]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04247263  1.06088521  4.09710023  9.25313333 16.94604727 25.34985036]
++[0.00130544 0.01107241 0.02547975 0.04953334 0.17200736 0.44466769]
+ Performing replicate 148 / 200
+-[  0.03982678   1.07264906   4.10198652   9.22584286  16.81294905
+-  25.75419853]
+-[ 0.0012693   0.01063751  0.02593565  0.0479869   0.17544967  0.51410323]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03948504  1.0417179   4.13473866  9.21575116 16.67783787 25.04794447]
++[0.00122683 0.01074013 0.02610383 0.04831819 0.17180627 0.4315699 ]
+ Performing replicate 149 / 200
+-[  0.03950524   1.05342774   4.08868466   9.28111385  17.03683543
+-  26.26077134]
+-[ 0.0012436   0.01103079  0.02575514  0.04977335  0.17523492  0.66081985]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.03967424  1.03616867  4.16001326  9.27205735 17.03401188 25.14820512]
++[0.00119554 0.01086735 0.02583886 0.04975345 0.17223631 0.39545792]
+ Performing replicate 150 / 200
+-[  0.04103854   1.06564037   4.10091067   9.24946845  16.85832655
+-  25.77860494]
+-[ 0.00123911  0.01080355  0.02570082  0.04926861  0.17414684  0.53573897]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.0402514   1.07549166  4.08710382  9.18316922 17.21452912 27.39192443]
++[0.00125881 0.01079044 0.02507131 0.04979174 0.18320188 0.73624437]
+ Performing replicate 151 / 200
+-[  0.0421703    1.07052286   4.15591606   9.26279647  17.0148897
+-  26.87139248]
+-[ 0.00131449  0.01131113  0.02585465  0.04885976  0.17908127  0.63926408]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04075875  1.06446981  4.12598608  9.18657692 17.00410277 26.12698844]
++[0.00124183 0.01094237 0.02523711 0.04957501 0.17589965 0.5859568 ]
+ Performing replicate 152 / 200
+-[  0.04283881   1.06075603   4.0949236    9.19495223  17.11194677
+-  25.93971633]
+-[ 0.00130255  0.01102937  0.02483143  0.04947497  0.1779809   0.43927266]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04101345  1.04763512  4.12009443  9.33151172 16.95590024 25.65889519]
++[0.00122857 0.01056484 0.02617427 0.04952269 0.17279317 0.4897494 ]
+ Performing replicate 153 / 200
+-[  0.04233202   1.05904998   4.11066753   9.2909831   17.09160179
+-  26.4795255 ]
+-[ 0.0012714   0.01113896  0.02557989  0.04980546  0.17527974  0.6553202 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03963724  1.04923664  4.1293401   9.19422398 16.7462357  26.54123029]
++[0.00119871 0.01100298 0.02539898 0.04932843 0.17533782 1.09747299]
+ Performing replicate 154 / 200
+-[  0.04033525   1.06779141   4.10535313   9.30277389  16.95386003
+-  25.50736905]
+-[ 0.00122583  0.01110686  0.02513268  0.0501842   0.17232498  0.4821687 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.0396528   1.05154947  4.12766231  9.1728756  16.97018007 27.61954165]
++[1.15938542e-03 1.07849564e-02 2.57724853e-02 4.88200586e-02
++ 1.79156984e-01 1.65805535e+00]
+ Performing replicate 155 / 200
+-[  0.04026612   1.09644873   4.16853794   9.24726474  16.90114481
+-  25.24258986]
+-[ 0.0012139   0.01100923  0.02671356  0.04786345  0.1725853   0.3901067 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.09e-12
++[ 0.03900252  1.06805543  4.11252292  9.23330868 17.30291588 27.15713116]
++[1.16619814e-03 1.08636843e-02 2.55805027e-02 5.05067515e-02
++ 1.79027988e-01 1.28821076e+00]
+ Performing replicate 156 / 200
+-[  0.03906261   1.09062096   4.14562783   9.22102642  16.81932758
+-  25.80535977]
+-[ 0.00117694  0.0111168   0.02529832  0.04911709  0.176728    0.44752374]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.83e-12
++[ 0.03825126  1.05068269  4.12024422  9.26866967 17.29864136 25.28958687]
++[0.00117603 0.01084838 0.02592029 0.04892434 0.17292209 0.38506866]
+ Performing replicate 157 / 200
+-[  0.04070245   1.08349564   4.087405     9.22263818  16.65246868
+-  25.01727819]
+-[ 0.0012579   0.01114315  0.02527657  0.04912778  0.17105104  0.42416007]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04074161  1.05983631  4.12708568  9.30425151 16.92876987 25.27429218]
++[0.00122668 0.01126359 0.02658345 0.04887155 0.16952013 0.4885423 ]
+ Performing replicate 158 / 200
+-[  0.038858     1.06436365   4.11346521   9.28805281  17.00700928
+-  25.94096547]
+-[ 0.00119331  0.01087144  0.025526    0.04949209  0.17435592  0.48873057]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03952316  1.06076929  4.09873444  9.2072707  16.99238426 26.99255113]
++[0.0011724  0.01109218 0.02559123 0.04922654 0.17896665 0.84293768]
+ Performing replicate 159 / 200
+-[  0.03863534   1.05785545   4.12211697   9.19493196  16.84859109
+-  26.38544488]
+-[ 0.00116276  0.01081988  0.02584204  0.04828893  0.1793468   0.51649675]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04013869  1.0586082   4.12627944  9.24362618 17.18610273 26.64651113]
++[0.00120888 0.01085788 0.02516004 0.05004442 0.17832514 0.59038519]
+ Performing replicate 160 / 200
+-[  0.04046122   1.04030794   4.11241122   9.20594922  16.65867485
+-  25.24791553]
+-[ 0.00123475  0.01059827  0.02570171  0.04948124  0.17060838  0.48291271]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.0413015   1.0667056   4.12340787  9.19371776 16.79472638 25.86591302]
++[0.00127358 0.01074239 0.02564696 0.04852287 0.1764254  0.55926236]
+ Performing replicate 161 / 200
+-[  0.04140849   1.07138653   4.13329869   9.20288428  17.02143001
+-  25.99473279]
+-[ 0.001329    0.01092943  0.02507844  0.04961145  0.17602735  0.49470899]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03988714  1.0546929   4.04783104  9.19355724 16.85821701 25.17722503]
++[0.00119341 0.01093701 0.02571522 0.04821304 0.17349739 0.39659871]
+ Performing replicate 162 / 200
+-[  0.04166616   1.0709341    4.10146952   9.17054636  16.87661293
+-  26.45863914]
+-[ 0.00126014  0.01079852  0.02572087  0.0487759   0.17724193  0.71373954]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03922439  1.0758835   4.14769951  9.29178673 17.15649697 26.37184533]
++[0.00126954 0.01115485 0.02541799 0.0497061  0.178426   0.52659086]
+ Performing replicate 163 / 200
+-[  0.04008722   1.05413579   4.10799876   9.26795049  16.81063176
+-  24.99624393]
+-[ 0.00125608  0.01100212  0.02566485  0.04938976  0.1703181   0.4161677 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03887405  1.0648428   4.14152851  9.28511942 16.8002774  25.32637094]
++[0.00119245 0.01085298 0.02565599 0.04912642 0.17267789 0.45782726]
+ Performing replicate 164 / 200
+-[  0.0387415    1.06646642   4.11179728   9.26236001  16.84517008
+-  25.10163539]
+-[ 0.00120862  0.01098634  0.02581575  0.04820443  0.17220011  0.40708557]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03835591  1.04481619  4.0999079   9.27746767 16.94448182 25.70249017]
++[0.00118826 0.01078933 0.02588856 0.04983371 0.17477258 0.42534349]
+ Performing replicate 165 / 200
+-[  0.0410829    1.05283067   4.0949469    9.27363586  17.07724205
+-  25.84018779]
+-[ 0.00125169  0.01102343  0.02632057  0.04843004  0.17503375  0.50340767]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03985571  1.06205082  4.10466417  9.28596488 16.80142765 25.07881475]
++[0.00126311 0.01093044 0.02551212 0.05029934 0.17011149 0.41537416]
+ Performing replicate 166 / 200
+-[  0.03964108   1.07658514   4.15483952   9.26922229  16.842489    25.5748169 ]
+-[ 0.00120427  0.0110258   0.02523857  0.04860376  0.17265797  0.48069811]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04085501  1.06088217  4.1127687   9.27350857 16.83044789 25.36641665]
++[0.00124942 0.01108553 0.02551076 0.0492831  0.17092589 0.49817389]
+ Performing replicate 167 / 200
+-[  0.04115877   1.04650405   4.09023549   9.23421001  16.84001286
+-  26.0646407 ]
+-[ 0.00123244  0.01086916  0.02530394  0.04886357  0.17471357  0.6034998 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.0417479   1.06398196  4.09452888  9.09345488 16.81847848 25.02200611]
++[0.00132671 0.01086001 0.02557125 0.04891484 0.17269353 0.42676554]
+ Performing replicate 168 / 200
+-[  0.03962136   1.04880228   4.11120813   9.28817162  16.95461118
+-  26.0747367 ]
+-[ 0.00121454  0.0107909   0.02593557  0.0497015   0.1759755   0.52477491]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04132402  1.06306073  4.14543788  9.22425213 16.909052   25.88161833]
++[0.00123794 0.01096245 0.02594427 0.04909392 0.17622597 0.49658656]
+ Performing replicate 169 / 200
+-[  0.03933242   1.0652405    4.13821324   9.29361812  16.94895642
+-  26.08980593]
+-[ 0.00118615  0.01101444  0.02588868  0.0496701   0.17644145  0.49070508]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04334952  1.07472803  4.11907721  9.23708481 16.93965848 25.5696248 ]
++[0.00133345 0.01095409 0.02557324 0.04970075 0.17279429 0.52423431]
+ Performing replicate 170 / 200
+-[  0.03924082   1.04870899   4.12174642   9.26434069  17.19187269
+-  25.53024351]
+-[ 0.00121825  0.01085487  0.02595499  0.05007439  0.17263563  0.4424045 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03914368  1.04005093  4.11601888  9.20718734 17.33242682 26.4266945 ]
++[0.0011637  0.01082222 0.02562728 0.05031351 0.1787362  0.49123531]
+ Performing replicate 171 / 200
+-[  0.04032347   1.06789577   4.09306472   9.20194451  17.26685859
+-  26.16562743]
+-[ 0.00124151  0.010981    0.02581321  0.05008271  0.17687769  0.52078582]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.03997725  1.0628203   4.13770212  9.3071347  16.75367996 26.2006745 ]
++[0.00123121 0.01090087 0.02541468 0.04923955 0.1742997  0.70244597]
+ Performing replicate 172 / 200
+-[  0.0392444    1.07221821   4.1263054    9.24548735  17.05286745
+-  25.95925097]
+-[ 0.00118465  0.01116946  0.02566478  0.04890527  0.17580603  0.48896266]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04065934  1.06302232  4.12713853  9.26509301 17.2235768  26.33786598]
++[0.00123969 0.010962   0.02565631 0.04938522 0.1754707  0.82666499]
+ Performing replicate 173 / 200
+-[  0.03971729   1.06171116   4.09255312   9.24492582  16.95772866
+-  26.12282377]
+-[ 0.0012028   0.01098921  0.0258358   0.04998143  0.17547126  0.54453633]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03914283  1.05229203  4.14504394  9.33218867 17.01584477 25.97850581]
++[0.00122253 0.0108431  0.02639148 0.04915235 0.17476396 0.57407044]
+ Performing replicate 174 / 200
+-[  0.04082981   1.05727036   4.07320823   9.32041326  17.02462864
+-  25.95365609]
+-[ 0.00124846  0.01082101  0.02537474  0.05062054  0.17437232  0.50413472]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.43e-12
++[ 0.04074304  1.07693259  4.10627348  9.22829772 16.84683766 25.82375379]
++[0.00122681 0.01131475 0.02554377 0.04910134 0.17469788 0.54660858]
+ Performing replicate 175 / 200
+-[  0.0391653    1.0826314    4.11553603   9.23761106  17.09492746
+-  25.48363107]
+-[ 0.00119351  0.01098443  0.02564818  0.04919253  0.17424364  0.39502371]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03967976  1.05561579  4.10602651  9.20229081 16.8768591  25.57468398]
++[0.00120809 0.01097673 0.02580072 0.04863555 0.17517975 0.47655956]
+ Performing replicate 176 / 200
+-[  0.04162999   1.04539376   4.13621659   9.25199983  17.22479623
+-  26.68295993]
+-[ 0.00126612  0.01073412  0.02545388  0.04960743  0.17992553  0.59287252]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03765345  1.06348833  4.13476548  9.22768176 16.75002859 25.67408393]
++[0.00112222 0.01109048 0.0260727  0.04909964 0.17279091 0.568084  ]
+ Performing replicate 177 / 200
+-[  0.040892     1.0671822    4.11941036   9.26315538  17.12733979
+-  25.48019854]
+-[ 0.00121534  0.01087971  0.02631539  0.04951128  0.17169236  0.45976469]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03964787  1.07404957  4.08347621  9.25861092 17.23642968 25.99004317]
++[0.00124437 0.01112153 0.02536146 0.05069958 0.17697784 0.46042888]
+ Performing replicate 178 / 200
+-[  0.040593     1.04735719   4.11480803   9.18996328  16.91438114
+-  25.61631068]
+-[ 0.00121006  0.0105619   0.02519179  0.048928    0.17699047  0.41568978]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04218991  1.04929403  4.12309822  9.19991365 16.86064208 25.55290092]
++[0.00131511 0.01075854 0.02576016 0.04882433 0.17394164 0.47489437]
+ Performing replicate 179 / 200
+-[  0.03949997   1.05983624   4.1161433    9.24289668  17.07069573
+-  25.94581591]
+-[ 0.00123058  0.01101692  0.02611206  0.04851842  0.17539834  0.49882988]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04113675  1.05677132  4.07609167  9.27176595 16.91881427 25.51713621]
++[0.00126032 0.01034274 0.02543807 0.0498377  0.17093882 0.6084041 ]
+ Performing replicate 180 / 200
+-[  0.04268441   1.04306007   4.13891794   9.27704161  16.97015949
+-  25.93576014]
+-[ 0.00127801  0.01066696  0.0258331   0.04922634  0.17440892  0.55836257]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04050788  1.05553897  4.1765127   9.19951095 17.13882675 26.16725938]
++[0.00120329 0.01103227 0.02582179 0.04964033 0.17752509 0.49837713]
+ Performing replicate 181 / 200
+-[  0.03997153   1.0679806    4.09171679   9.31222106  17.15616892
+-  26.37041466]
+-[ 0.00123118  0.01070067  0.02609698  0.0496551   0.17606712  0.5655925 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03922528  1.03847993  4.07477377  9.24126504 17.01294043 25.85593086]
++[0.00121071 0.01086685 0.02554272 0.04916098 0.17527238 0.48923393]
+ Performing replicate 182 / 200
+-[  0.03916729   1.0462345    4.04675658   9.27222361  16.91813772
+-  25.68211268]
+-[ 0.00122488  0.01057735  0.02650417  0.04849245  0.17562164  0.42935177]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.03917716  1.0628745   4.0761117   9.30997285 17.06776714 25.92724437]
++[0.00125504 0.01088776 0.02579925 0.05033104 0.1762384  0.45361692]
+ Performing replicate 183 / 200
+-[  0.04104305   1.08116288   4.093905     9.27785203  16.87299391
+-  25.6468424 ]
+-[ 0.00126306  0.01103343  0.02565125  0.04860066  0.17202623  0.58639778]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.26e-12
++[ 0.04034922  1.06076492  4.11632747  9.33255042 17.12372612 25.71913407]
++[0.00128512 0.01105564 0.02548206 0.05015886 0.17262883 0.57342372]
+ Performing replicate 184 / 200
+-[  0.04017636   1.06085919   4.09406332   9.19915067  16.79677292
+-  25.93005427]
+-[ 0.00120525  0.01083511  0.02512188  0.04932081  0.17543116  0.54611401]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03883601  1.05516603  4.03578921  9.22865944 16.69866365 25.0440894 ]
++[0.0011963  0.01085288 0.02561758 0.04875598 0.17139263 0.41026031]
+ Performing replicate 185 / 200
+-[  0.04198703   1.04706363   4.05060448   9.30064134  16.94518554
+-  26.03703662]
+-[ 0.00130929  0.01083047  0.02541583  0.04960069  0.17732444  0.47394367]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04255949  1.0548528   4.12206072  9.20923324 16.9765651  25.76771089]
++[0.00123714 0.01074133 0.02660145 0.04932054 0.17356895 0.62180151]
+ Performing replicate 186 / 200
+-[  0.03995719   1.0812905    4.11385805   9.34922996  17.3113262
+-  26.72903961]
+-[ 0.00123332  0.01089008  0.02645681  0.05054283  0.17738668  0.64498736]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03786707  1.0842681   4.1139317   9.26646697 16.89970607 25.64714825]
++[0.00118771 0.01120414 0.02516133 0.04969422 0.17199565 0.56021551]
+ Performing replicate 187 / 200
+-[  0.04178661   1.04738889   4.08764344   9.19222811  17.09856684
+-  27.02318802]
+-[ 0.00124473  0.0108632   0.02530931  0.04930682  0.18064872  0.70583336]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03885175  1.06401962  4.0953245   9.22816814 17.15613398 26.26410598]
++[0.00117114 0.01084865 0.02598598 0.04936978 0.17778601 0.49034042]
+ Performing replicate 188 / 200
+-[  0.03815262   1.06627266   4.1017307    9.19193494  16.92183004
+-  25.15194766]
+-[ 0.00115353  0.01122614  0.02492129  0.04904429  0.1714296   0.46277932]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.08e-12
++[ 0.03916907  1.06195567  4.09631427  9.20990299 17.15550258 26.2847235 ]
++[0.00118885 0.01079848 0.02587778 0.04907878 0.18019443 0.44079388]
+ Performing replicate 189 / 200
+-[  0.04185249   1.05044745   4.07419763   9.18283925  16.96688124
+-  26.25445596]
+-[ 0.00127318  0.01111222  0.02580958  0.04904387  0.17461487  0.82896019]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03778221  1.0496314   4.14973278  9.33390347 17.35876632 26.06781097]
++[0.0011929  0.01081494 0.0260036  0.04993709 0.17287074 0.65602686]
+ Performing replicate 190 / 200
+-[  0.04013031   1.05129657   4.12751049   9.29690192  17.25226686
+-  26.4353545 ]
+-[ 0.00125514  0.01080433  0.02645488  0.04910563  0.17889221  0.48625833]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++[ 0.04107742  1.08007828  4.08829975  9.14858776 16.81771564 26.13745563]
++[0.00123871 0.01115557 0.02513659 0.0491685  0.17612711 0.86093237]
+ Performing replicate 191 / 200
+-[  0.04245385   1.05526463   4.09175209   9.29643086  16.90897975
+-  26.12822411]
+-[ 0.00128934  0.01080084  0.02594365  0.04952361  0.17444127  0.63108606]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.03964298  1.06450389  4.10744734  9.27163908 17.22632445 26.61916102]
++[0.00122403 0.01101905 0.02528958 0.04988069 0.17977885 0.58241499]
+ Performing replicate 192 / 200
+-[  0.03939741   1.06506177   4.12351384   9.31724781  17.38964044
+-  26.23684384]
+-[ 0.00125671  0.0109246   0.02568841  0.0500429   0.17853105  0.49399573]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 9.42e-13
++[ 0.0398146   1.05284374  4.08416859  9.27625284 17.07926581 25.25671039]
++[0.00123174 0.01092759 0.02558197 0.04874624 0.17273435 0.39190106]
+ Performing replicate 193 / 200
+-[  0.03998072   1.07018011   4.11376889   9.28750939  16.9131847
+-  25.48530037]
+-[ 0.00124424  0.01106459  0.02607634  0.04907463  0.1724432   0.46890669]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.68e-12
++[ 0.03846028  1.05082904  4.12306679  9.30995412 17.26432513 25.90934975]
++[0.00118513 0.01067334 0.02554032 0.04956267 0.17369254 0.51562942]
+ Performing replicate 194 / 200
+-[  0.03996269   1.05972543   4.11531239   9.28403013  16.62235584
+-  24.77307246]
+-[ 0.00121992  0.01089392  0.02644425  0.04882868  0.1669324   0.45633012]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04241041  1.06226337  4.14106477  9.19670241 17.10338225 26.20609885]
++[0.00130314 0.01102521 0.02514543 0.05043752 0.17725599 0.51428122]
+ Performing replicate 195 / 200
+-[  0.0389021    1.07285365   4.09265839   9.291044    16.68839384
+-  24.53532919]
+-[ 0.00120791  0.01105546  0.0260614   0.04977696  0.16517615  0.40374384]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.0389781   1.0717443   4.06721461  9.156016   17.15954345 25.9435764 ]
++[0.00120403 0.0108145  0.02534289 0.04982075 0.17844693 0.4502166 ]
+ Performing replicate 196 / 200
+-[  0.03820896   1.06562087   4.12246071   9.28038403  16.9777533
+-  25.60066381]
+-[ 0.00114809  0.0108086   0.02602538  0.04933105  0.17182912  0.50621923]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04040425  1.08273101  4.04965734  9.28964361 16.81022322 25.57520469]
++[0.00121953 0.01078653 0.02594205 0.0485129  0.1747217  0.44656067]
+ Performing replicate 197 / 200
+-[  0.03961265   1.05123143   4.13552453   9.29155693  17.01434371
+-  26.7809199 ]
+-[ 0.00123017  0.01086232  0.02591244  0.04999904  0.17486925  1.0911329 ]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.6e-12
++[ 0.04225357  1.08785083  4.13716652  9.26753743 17.04926272 25.41591015]
++[0.00131668 0.01092811 0.02585182 0.04985847 0.17281623 0.4083112 ]
+ Performing replicate 198 / 200
+-[  0.03889642   1.07099961   4.14408392   9.23450485  17.17766108
+-  26.65097084]
+-[ 0.00117274  0.01102282  0.02536606  0.04985116  0.1773005   0.72667978]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.51e-12
++[ 0.04080864  1.05578917  4.12542644  9.26846494 17.2013009  26.12837111]
++[0.00125068 0.01089593 0.02535943 0.04918443 0.17650576 0.51148002]
+ Performing replicate 199 / 200
+-[  0.04127325   1.0568403    4.10224829   9.26011535  16.65155574
+-  24.59976436]
+-[ 0.00123371  0.01066127  0.02576043  0.04933736  0.16771452  0.41132017]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04037436  1.0602233   4.12043147  9.30622192 16.90120418 26.38462644]
++[0.00126113 0.01079958 0.0262764  0.04862392 0.17454117 1.07843245]
+ Performing replicate 200 / 200
+-[  0.03843392   1.05559499   4.11173046   9.3156173   17.01134082
+-  26.14293771]
+-[ 0.00117839  0.01084721  0.02509163  0.05022886  0.17425602  0.54584475]
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with adaptive
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 0
++[ 0.04202009  1.04714895  4.11384316  9.22402556 16.73935212 25.20267944]
++[0.0012903  0.01061105 0.02615075 0.04939276 0.17100542 0.4336926 ]
+ Free energies
+ Anderson-Darling Metrics (see README.md)
+-[[ 0.          1.28950265  1.22372038  1.19571806  1.29453297  1.29706093]
+- [ 0.92104011  0.          1.11743234  0.38514148  0.39310714  0.7255426 ]
+- [ 0.76238837  0.73065943  0.          0.38600061  0.3219965   0.27862602]
+- [ 0.84943314  0.22877813  0.67881642  0.          0.37026049  1.22756765]
+- [ 0.95619074  0.23467976  0.60820073  0.48639343  0.          3.21878282]
+- [ 0.87460656  0.44539327  0.31457453  0.9575389   2.70933039  0.        ]]
+-The uncertainty estimates are tested in this section.
++[[0.         0.63948233 0.64238618 0.56374172 0.5247762  0.62654248]
++ [0.49202939 0.         0.57771277 0.64306131 0.50730763 0.81995768]
++ [0.4305121  0.40320521 0.         0.50130062 0.49338421 0.58437865]
++ [0.37731585 0.49778176 0.53050247 0.         0.93139412 1.16545921]
++ [0.28301623 0.28782605 0.33423671 0.59964086 0.         1.81114272]
++ [0.32242773 0.51940134 0.29650744 0.77617482 1.46701154 0.        ]]
++INFO:pymbar.confidenceintervals:The uncertainty estimates are tested in this section.
+ If the error is normally distributed, the actual error will be less than a
+ multiplier 'alpha' times the computed uncertainty 'sigma' a fraction of
+ time given by:
+@@ -833,60 +1248,60 @@ A weak lower bound that holds regardless of how the error is distributed is give
+ by Chebyshev's inequality, and is listed as 'cheby' below.
+ Uncertainty estimates are tested for both free energy differences and expectations.
+ 
+-Error vs. alpha
+-alpha      cheby        obs          obs err            normal
+-  0.1 -99.000000   0.084610 (  0.074922,  0.094823)   0.079656
+-  0.2 -24.000000   0.161892 (  0.148933,  0.175278)   0.158519
+-  0.3 -10.111111   0.232845 (  0.217899,  0.248128)   0.235823
+-  0.4  -5.250000   0.300133 (  0.283869,  0.316650)   0.310843
+-  0.5  -3.000000   0.369420 (  0.352242,  0.386764)   0.382925
+-  0.6  -1.777778   0.436043 (  0.418348,  0.453818)   0.451494
+-  0.7  -1.040816   0.500666 (  0.482784,  0.518548)   0.516073
+-  0.8  -0.562500   0.558294 (  0.540498,  0.576017)   0.576289
+-  0.9  -0.234568   0.615923 (  0.598455,  0.633244)   0.631880
+-  1.0  -0.000000   0.666889 (  0.649927,  0.683639)   0.682689
+-  1.1   0.173554   0.710526 (  0.694174,  0.726612)   0.728668
+-  1.2   0.305556   0.751166 (  0.735546,  0.766469)   0.769861
+-  1.3   0.408284   0.798468 (  0.783934,  0.812625)   0.806399
+-  1.4   0.489796   0.832112 (  0.818536,  0.845268)   0.838487
+-  1.5   0.555556   0.854430 (  0.841595,  0.866818)   0.866386
+-  1.6   0.609375   0.880080 (  0.868224,  0.891457)   0.890401
+-  1.7   0.653979   0.900733 (  0.889788,  0.911172)   0.910869
+-  1.8   0.691358   0.920053 (  0.910092,  0.929485)   0.928139
+-  1.9   0.722992   0.935376 (  0.926312,  0.943891)   0.942567
+-  2.0   0.750000   0.946369 (  0.938034,  0.954141)   0.954500
+-  2.1   0.773243   0.955363 (  0.947695,  0.962457)   0.964271
+-  2.2   0.793388   0.965023 (  0.958164,  0.971296)   0.972193
+-  2.3   0.810964   0.972019 (  0.965829,  0.977613)   0.978552
+-  2.4   0.826389   0.978348 (  0.972848,  0.983245)   0.983605
+-  2.5   0.840000   0.984011 (  0.979227,  0.988184)   0.987581
+-  2.6   0.852071   0.989340 (  0.985369,  0.992695)   0.990678
+-  2.7   0.862826   0.991672 (  0.988124,  0.994602)   0.993066
+-  2.8   0.872449   0.993338 (  0.990131,  0.995925)   0.994890
+-  2.9   0.881094   0.995003 (  0.992185,  0.997200)   0.996268
+-  3.0   0.888889   0.997335 (  0.995200,  0.998848)   0.997300
+-  3.1   0.895942   0.997668 (  0.995653,  0.999062)   0.998065
+-  3.2   0.902344   0.997668 (  0.995653,  0.999062)   0.998626
+-  3.3   0.908173   0.998334 (  0.996591,  0.999459)   0.999033
+-  3.4   0.913495   0.998668 (  0.997081,  0.999637)   0.999326
+-  3.5   0.918367   0.999001 (  0.997595,  0.999794)   0.999535
+-  3.6   0.922840   0.999334 (  0.998145,  0.999919)   0.999682
+-  3.7   0.926954   0.999334 (  0.998145,  0.999919)   0.999784
+-  3.8   0.930748   0.999667 (  0.998772,  0.999992)   0.999855
+-  3.9   0.934254   0.999667 (  0.998772,  0.999992)   0.999904
+-  4.0   0.937500   0.999667 (  0.998772,  0.999992)   0.999937
+-
+-     i      average    bias      rms_error     stddev  ave_analyt_std
+----------------------------------------------------------------------
+-      0     0.0000      0.0000      0.0000      0.0000     0.0000
+-      1    -0.2149      0.0082      0.1620      0.1618     0.1554
+-      2    -0.4987      0.0121      0.1856      0.1852     0.1768
+-      3    -0.9060      0.0103      0.1902      0.1899     0.1825
+-      4    -1.5992      0.0102      0.1917      0.1915     0.1838
+-      5    -1.5971      0.0123      0.1935      0.1931     0.1881
+-Totals:    -1.5971      0.0123      0.1935      0.1931     0.1881
++INFO:pymbar.confidenceintervals:Error vs. alpha
++INFO:pymbar.confidenceintervals:alpha cheby      obs        obs err          normal           
++INFO:pymbar.confidenceintervals:  0.1 -99.000000   0.075949 (  0.066745,  0.085688)   0.079656
++INFO:pymbar.confidenceintervals:  0.2 -24.000000   0.147568 (  0.135108,  0.160473)   0.158519
++INFO:pymbar.confidenceintervals:  0.3 -10.111111   0.217855 (  0.203271,  0.232795)   0.235823
++INFO:pymbar.confidenceintervals:  0.4  -5.250000   0.287142 (  0.271096,  0.303456)   0.310843
++INFO:pymbar.confidenceintervals:  0.5  -3.000000   0.359094 (  0.342026,  0.376340)   0.382925
++INFO:pymbar.confidenceintervals:  0.6  -1.777778   0.431712 (  0.414041,  0.449469)   0.451494
++INFO:pymbar.confidenceintervals:  0.7  -1.040816   0.492672 (  0.474796,  0.510556)   0.516073
++INFO:pymbar.confidenceintervals:  0.8  -0.562500   0.558961 (  0.541167,  0.576680)   0.576289
++INFO:pymbar.confidenceintervals:  0.9  -0.234568   0.621252 (  0.603828,  0.638524)   0.631880
++INFO:pymbar.confidenceintervals:  1.0  -0.000000   0.681879 (  0.665108,  0.698420)   0.682689
++INFO:pymbar.confidenceintervals:  1.1   0.173554   0.731179 (  0.715178,  0.746888)   0.728668
++INFO:pymbar.confidenceintervals:  1.2   0.305556   0.766156 (  0.750851,  0.781125)   0.769861
++INFO:pymbar.confidenceintervals:  1.3   0.408284   0.810127 (  0.795905,  0.823956)   0.806399
++INFO:pymbar.confidenceintervals:  1.4   0.489796   0.842438 (  0.829194,  0.855251)   0.838487
++INFO:pymbar.confidenceintervals:  1.5   0.555556   0.868754 (  0.856447,  0.880596)   0.866386
++INFO:pymbar.confidenceintervals:  1.6   0.609375   0.888408 (  0.876904,  0.899421)   0.890401
++INFO:pymbar.confidenceintervals:  1.7   0.653979   0.901732 (  0.890835,  0.912122)   0.910869
++INFO:pymbar.confidenceintervals:  1.8   0.691358   0.919387 (  0.909389,  0.928856)   0.928139
++INFO:pymbar.confidenceintervals:  1.9   0.722992   0.932378 (  0.923129,  0.941083)   0.942567
++INFO:pymbar.confidenceintervals:  2.0   0.750000   0.945037 (  0.936609,  0.952903)   0.954500
++INFO:pymbar.confidenceintervals:  2.1   0.773243   0.956029 (  0.948413,  0.963070)   0.964271
++INFO:pymbar.confidenceintervals:  2.2   0.793388   0.968021 (  0.961439,  0.974013)   0.972193
++INFO:pymbar.confidenceintervals:  2.3   0.810964   0.974350 (  0.968404,  0.979699)   0.978552
++INFO:pymbar.confidenceintervals:  2.4   0.826389   0.981013 (  0.975836,  0.985583)   0.983605
++INFO:pymbar.confidenceintervals:  2.5   0.840000   0.984677 (  0.979986,  0.988757)   0.987581
++INFO:pymbar.confidenceintervals:  2.6   0.852071   0.989340 (  0.985369,  0.992695)   0.990678
++INFO:pymbar.confidenceintervals:  2.7   0.862826   0.993005 (  0.989726,  0.995663)   0.993066
++INFO:pymbar.confidenceintervals:  2.8   0.872449   0.993671 (  0.990537,  0.996184)   0.994890
++INFO:pymbar.confidenceintervals:  2.9   0.881094   0.996003 (  0.993451,  0.997932)   0.996268
++INFO:pymbar.confidenceintervals:  3.0   0.888889   0.997002 (  0.994754,  0.998628)   0.997300
++INFO:pymbar.confidenceintervals:  3.1   0.895942   0.998334 (  0.996591,  0.999459)   0.998065
++INFO:pymbar.confidenceintervals:  3.2   0.902344   0.999334 (  0.998145,  0.999919)   0.998626
++INFO:pymbar.confidenceintervals:  3.3   0.908173   0.999334 (  0.998145,  0.999919)   0.999033
++INFO:pymbar.confidenceintervals:  3.4   0.913495   0.999334 (  0.998145,  0.999919)   0.999326
++INFO:pymbar.confidenceintervals:  3.5   0.918367   0.999667 (  0.998772,  0.999992)   0.999535
++INFO:pymbar.confidenceintervals:  3.6   0.922840   0.999667 (  0.998772,  0.999992)   0.999682
++INFO:pymbar.confidenceintervals:  3.7   0.926954   0.999667 (  0.998772,  0.999992)   0.999784
++INFO:pymbar.confidenceintervals:  3.8   0.930748   0.999667 (  0.998772,  0.999992)   0.999855
++INFO:pymbar.confidenceintervals:  3.9   0.934254   0.999667 (  0.998772,  0.999992)   0.999904
++INFO:pymbar.confidenceintervals:  4.0   0.937500   0.999667 (  0.998772,  0.999992)   0.999937
++INFO:pymbar.confidenceintervals:
++INFO:pymbar.confidenceintervals:     i      average    bias      rms_error     stddev  ave_analyt_std
++INFO:pymbar.confidenceintervals:---------------------------------------------------------------------
++INFO:pymbar.confidenceintervals:      0     0.0000      0.0000      0.0000      0.0000     0.0000
++INFO:pymbar.confidenceintervals:      1    -0.2184      0.0047      0.1547      0.1546     0.1551
++INFO:pymbar.confidenceintervals:      2    -0.5048      0.0061      0.1802      0.1801     0.1765
++INFO:pymbar.confidenceintervals:      3    -0.9105      0.0058      0.1841      0.1840     0.1822
++INFO:pymbar.confidenceintervals:      4    -1.6024      0.0070      0.1840      0.1839     0.1835
++INFO:pymbar.confidenceintervals:      5    -1.6010      0.0084      0.1885      0.1883     0.1879
++INFO:pymbar.confidenceintervals:Totals:    -1.6010      0.0084      0.1885      0.1883     0.1879
+ Standard ensemble averaged observables
+-The uncertainty estimates are tested in this section.
++INFO:pymbar.confidenceintervals:The uncertainty estimates are tested in this section.
+ If the error is normally distributed, the actual error will be less than a
+ multiplier 'alpha' times the computed uncertainty 'sigma' a fraction of
+ time given by:
+@@ -901,61 +1316,61 @@ A weak lower bound that holds regardless of how the error is distributed is give
+ by Chebyshev's inequality, and is listed as 'cheby' below.
+ Uncertainty estimates are tested for both free energy differences and expectations.
+ 
+-Error vs. alpha
+-alpha      cheby        obs          obs err            normal
+-  0.1 -99.000000   0.081836 (  0.065680,  0.099573)   0.079656
+-  0.2 -24.000000   0.161677 (  0.139544,  0.185088)   0.158519
+-  0.3 -10.111111   0.239521 (  0.213610,  0.266417)   0.235823
+-  0.4  -5.250000   0.305389 (  0.277262,  0.334253)   0.310843
+-  0.5  -3.000000   0.368263 (  0.338670,  0.398356)   0.382925
+-  0.6  -1.777778   0.431138 (  0.400626,  0.461910)   0.451494
+-  0.7  -1.040816   0.505988 (  0.475042,  0.536911)   0.516073
+-  0.8  -0.562500   0.563872 (  0.533068,  0.594435)   0.576289
+-  0.9  -0.234568   0.606786 (  0.576362,  0.636807)   0.631880
+-  1.0  -0.000000   0.663673 (  0.634132,  0.692594)   0.682689
+-  1.1   0.173554   0.711577 (  0.683148,  0.739205)   0.728668
+-  1.2   0.305556   0.757485 (  0.730482,  0.783514)   0.769861
+-  1.3   0.408284   0.796407 (  0.770937,  0.820757)   0.806399
+-  1.4   0.489796   0.828343 (  0.804397,  0.851048)   0.838487
+-  1.5   0.555556   0.865269 (  0.843462,  0.885697)   0.866386
+-  1.6   0.609375   0.888224 (  0.868004,  0.906975)   0.890401
+-  1.7   0.653979   0.915170 (  0.897159,  0.931612)   0.910869
+-  1.8   0.691358   0.928144 (  0.911371,  0.943298)   0.928139
+-  1.9   0.722992   0.945110 (  0.930195,  0.958343)   0.942567
+-  2.0   0.750000   0.955090 (  0.941438,  0.967024)   0.954500
+-  2.1   0.773243   0.964072 (  0.951706,  0.974687)   0.964271
+-  2.2   0.793388   0.969062 (  0.957491,  0.978863)   0.972193
+-  2.3   0.810964   0.973054 (  0.962172,  0.982151)   0.978552
+-  2.4   0.826389   0.981038 (  0.971729,  0.988534)   0.983605
+-  2.5   0.840000   0.985030 (  0.976645,  0.991589)   0.987581
+-  2.6   0.852071   0.990020 (  0.983001,  0.995199)   0.990678
+-  2.7   0.862826   0.993014 (  0.987000,  0.997184)   0.993066
+-  2.8   0.872449   0.993014 (  0.987000,  0.997184)   0.994890
+-  2.9   0.881094   0.994012 (  0.988382,  0.997797)   0.996268
+-  3.0   0.888889   0.997006 (  0.992801,  0.999382)   0.997300
+-  3.1   0.895942   0.997006 (  0.992801,  0.999382)   0.998065
+-  3.2   0.902344   0.998004 (  0.994447,  0.999758)   0.998626
+-  3.3   0.908173   0.998004 (  0.994447,  0.999758)   0.999033
+-  3.4   0.913495   0.999002 (  0.996322,  0.999975)   0.999326
+-  3.5   0.918367   0.999002 (  0.996322,  0.999975)   0.999535
+-  3.6   0.922840   0.999002 (  0.996322,  0.999975)   0.999682
+-  3.7   0.926954   0.999002 (  0.996322,  0.999975)   0.999784
+-  3.8   0.930748   0.999002 (  0.996322,  0.999975)   0.999855
+-  3.9   0.934254   0.999002 (  0.996322,  0.999975)   0.999904
+-  4.0   0.937500   0.999002 (  0.996322,  0.999975)   0.999937
+-
+-     i      average    bias      rms_error     stddev  ave_analyt_std
+----------------------------------------------------------------------
+-      0     0.0399     -0.0001      0.0013      0.0013     0.0013
+-      1     1.0629      0.0004      0.0116      0.0116     0.0113
+-      2     4.1105     -0.0006      0.0306      0.0306     0.0300
+-      3     9.2578      0.0078      0.0664      0.0659     0.0675
+-      4    16.9898     -0.0102      0.1829      0.1826     0.1816
+-Totals:    16.9898     -0.0102      0.1829      0.1826     0.1816
++INFO:pymbar.confidenceintervals:Error vs. alpha
++INFO:pymbar.confidenceintervals:alpha cheby      obs        obs err          normal           
++INFO:pymbar.confidenceintervals:  0.1 -99.000000   0.076846 (  0.061180,  0.094111)   0.079656
++INFO:pymbar.confidenceintervals:  0.2 -24.000000   0.158683 (  0.136727,  0.181928)   0.158519
++INFO:pymbar.confidenceintervals:  0.3 -10.111111   0.234531 (  0.208820,  0.261245)   0.235823
++INFO:pymbar.confidenceintervals:  0.4  -5.250000   0.308383 (  0.280172,  0.337319)   0.310843
++INFO:pymbar.confidenceintervals:  0.5  -3.000000   0.389222 (  0.359264,  0.419598)   0.382925
++INFO:pymbar.confidenceintervals:  0.6  -1.777778   0.438124 (  0.407542,  0.468940)   0.451494
++INFO:pymbar.confidenceintervals:  0.7  -1.040816   0.509980 (  0.479030,  0.540892)   0.516073
++INFO:pymbar.confidenceintervals:  0.8  -0.562500   0.568862 (  0.538090,  0.599374)   0.576289
++INFO:pymbar.confidenceintervals:  0.9  -0.234568   0.632735 (  0.602658,  0.662310)   0.631880
++INFO:pymbar.confidenceintervals:  1.0  -0.000000   0.690619 (  0.661660,  0.718857)   0.682689
++INFO:pymbar.confidenceintervals:  1.1   0.173554   0.732535 (  0.704710,  0.759480)   0.728668
++INFO:pymbar.confidenceintervals:  1.2   0.305556   0.779441 (  0.753263,  0.804563)   0.769861
++INFO:pymbar.confidenceintervals:  1.3   0.408284   0.819361 (  0.794959,  0.842556)   0.806399
++INFO:pymbar.confidenceintervals:  1.4   0.489796   0.851297 (  0.828627,  0.872640)   0.838487
++INFO:pymbar.confidenceintervals:  1.5   0.555556   0.874251 (  0.853038,  0.894050)   0.866386
++INFO:pymbar.confidenceintervals:  1.6   0.609375   0.893214 (  0.873372,  0.911569)   0.890401
++INFO:pymbar.confidenceintervals:  1.7   0.653979   0.912176 (  0.893897,  0.928897)   0.910869
++INFO:pymbar.confidenceintervals:  1.8   0.691358   0.926148 (  0.909176,  0.941510)   0.928139
++INFO:pymbar.confidenceintervals:  1.9   0.722992   0.944112 (  0.929079,  0.957467)   0.942567
++INFO:pymbar.confidenceintervals:  2.0   0.750000   0.954092 (  0.940306,  0.966163)   0.954500
++INFO:pymbar.confidenceintervals:  2.1   0.773243   0.965070 (  0.952857,  0.975527)   0.964271
++INFO:pymbar.confidenceintervals:  2.2   0.793388   0.974052 (  0.963352,  0.982964)   0.972193
++INFO:pymbar.confidenceintervals:  2.3   0.810964   0.980040 (  0.970517,  0.987754)   0.978552
++INFO:pymbar.confidenceintervals:  2.4   0.826389   0.987026 (  0.979153,  0.993067)   0.983605
++INFO:pymbar.confidenceintervals:  2.5   0.840000   0.991018 (  0.984314,  0.995881)   0.987581
++INFO:pymbar.confidenceintervals:  2.6   0.852071   0.993014 (  0.987000,  0.997184)   0.990678
++INFO:pymbar.confidenceintervals:  2.7   0.862826   0.995010 (  0.989801,  0.998376)   0.993066
++INFO:pymbar.confidenceintervals:  2.8   0.872449   0.998004 (  0.994447,  0.999758)   0.994890
++INFO:pymbar.confidenceintervals:  2.9   0.881094   0.999002 (  0.996322,  0.999975)   0.996268
++INFO:pymbar.confidenceintervals:  3.0   0.888889   0.999002 (  0.996322,  0.999975)   0.997300
++INFO:pymbar.confidenceintervals:  3.1   0.895942   0.999002 (  0.996322,  0.999975)   0.998065
++INFO:pymbar.confidenceintervals:  3.2   0.902344   0.999002 (  0.996322,  0.999975)   0.998626
++INFO:pymbar.confidenceintervals:  3.3   0.908173   0.999002 (  0.996322,  0.999975)   0.999033
++INFO:pymbar.confidenceintervals:  3.4   0.913495   0.999002 (  0.996322,  0.999975)   0.999326
++INFO:pymbar.confidenceintervals:  3.5   0.918367   0.999002 (  0.996322,  0.999975)   0.999535
++INFO:pymbar.confidenceintervals:  3.6   0.922840   0.999002 (  0.996322,  0.999975)   0.999682
++INFO:pymbar.confidenceintervals:  3.7   0.926954   0.999002 (  0.996322,  0.999975)   0.999784
++INFO:pymbar.confidenceintervals:  3.8   0.930748   0.999002 (  0.996322,  0.999975)   0.999855
++INFO:pymbar.confidenceintervals:  3.9   0.934254   0.999002 (  0.996322,  0.999975)   0.999904
++INFO:pymbar.confidenceintervals:  4.0   0.937500   0.999002 (  0.996322,  0.999975)   0.999937
++INFO:pymbar.confidenceintervals:
++INFO:pymbar.confidenceintervals:     i      average    bias      rms_error     stddev  ave_analyt_std
++INFO:pymbar.confidenceintervals:---------------------------------------------------------------------
++INFO:pymbar.confidenceintervals:      0     0.0400     -0.0000      0.0012      0.0012     0.0013
++INFO:pymbar.confidenceintervals:      1     1.0616     -0.0009      0.0116      0.0115     0.0113
++INFO:pymbar.confidenceintervals:      2     4.1124      0.0013      0.0298      0.0298     0.0301
++INFO:pymbar.confidenceintervals:      3     9.2495     -0.0005      0.0593      0.0593     0.0675
++INFO:pymbar.confidenceintervals:      4    16.9911     -0.0089      0.1877      0.1875     0.1817
++INFO:pymbar.confidenceintervals:Totals:    16.9911     -0.0089      0.1877      0.1875     0.1817
+ Anderson-Darling Metrics (see README.md)
+-[ 2.13488553  0.79787475  0.11485075  1.7653048   0.68530093]
++[0.41460745 0.44599936 0.93761647 1.3195594  0.68606603]
+ MBAR ensemble averaged observables
+-The uncertainty estimates are tested in this section.
++INFO:pymbar.confidenceintervals:The uncertainty estimates are tested in this section.
+ If the error is normally distributed, the actual error will be less than a
+ multiplier 'alpha' times the computed uncertainty 'sigma' a fraction of
+ time given by:
+@@ -970,64 +1385,63 @@ A weak lower bound that holds regardless of how the error is distributed is give
+ by Chebyshev's inequality, and is listed as 'cheby' below.
+ Uncertainty estimates are tested for both free energy differences and expectations.
+ 
+-Error vs. alpha
+-alpha      cheby        obs          obs err            normal
+-  0.1 -99.000000   0.077371 (  0.062952,  0.093121)   0.079656
+-  0.2 -24.000000   0.172213 (  0.151402,  0.194057)   0.158519
+-  0.3 -10.111111   0.247088 (  0.223120,  0.271853)   0.235823
+-  0.4  -5.250000   0.306156 (  0.280423,  0.332501)   0.310843
+-  0.5  -3.000000   0.375208 (  0.348050,  0.402760)   0.382925
+-  0.6  -1.777778   0.440932 (  0.412973,  0.469076)   0.451494
+-  0.7  -1.040816   0.508319 (  0.480061,  0.536552)   0.516073
+-  0.8  -0.562500   0.561564 (  0.533433,  0.589501)   0.576289
+-  0.9  -0.234568   0.613145 (  0.585450,  0.640483)   0.631880
+-  1.0  -0.000000   0.662230 (  0.635254,  0.688694)   0.682689
+-  1.1   0.173554   0.712146 (  0.686233,  0.737391)   0.728668
+-  1.2   0.305556   0.756240 (  0.731581,  0.780091)   0.769861
+-  1.3   0.408284   0.782862 (  0.759125,  0.805707)   0.806399
+-  1.4   0.489796   0.816972 (  0.794629,  0.838315)   0.838487
+-  1.5   0.555556   0.847754 (  0.826914,  0.867498)   0.866386
+-  1.6   0.609375   0.875208 (  0.855952,  0.893282)   0.890401
+-  1.7   0.653979   0.895175 (  0.877253,  0.911851)   0.910869
+-  1.8   0.691358   0.911814 (  0.895154,  0.927176)   0.928139
+-  1.9   0.722992   0.929285 (  0.914137,  0.943080)   0.942567
+-  2.0   0.750000   0.940932 (  0.926931,  0.953544)   0.954500
+-  2.1   0.773243   0.951747 (  0.938944,  0.963128)   0.964271
+-  2.2   0.793388   0.960899 (  0.949240,  0.971107)   0.972193
+-  2.3   0.810964   0.969218 (  0.958742,  0.978218)   0.978552
+-  2.4   0.826389   0.975042 (  0.965505,  0.983085)   0.983605
+-  2.5   0.840000   0.980033 (  0.971402,  0.987155)   0.987581
+-  2.6   0.852071   0.984193 (  0.976416,  0.990449)   0.990678
+-  2.7   0.862826   0.989185 (  0.982612,  0.994224)   0.993066
+-  2.8   0.872449   0.992512 (  0.986917,  0.996568)   0.994890
+-  2.9   0.881094   0.993344 (  0.988028,  0.997120)   0.996268
+-  3.0   0.888889   0.994176 (  0.989158,  0.997654)   0.997300
+-  3.1   0.895942   0.995840 (  0.991495,  0.998647)   0.998065
+-  3.2   0.902344   0.997504 (  0.993998,  0.999485)   0.998626
+-  3.3   0.908173   0.997504 (  0.993998,  0.999485)   0.999033
+-  3.4   0.913495   0.997504 (  0.993998,  0.999485)   0.999326
+-  3.5   0.918367   0.998336 (  0.995370,  0.999798)   0.999535
+-  3.6   0.922840   0.998336 (  0.995370,  0.999798)   0.999682
+-  3.7   0.926954   0.999168 (  0.996933,  0.999979)   0.999784
+-  3.8   0.930748   0.999168 (  0.996933,  0.999979)   0.999855
+-  3.9   0.934254   0.999168 (  0.996933,  0.999979)   0.999904
+-  4.0   0.937500   0.999168 (  0.996933,  0.999979)   0.999937
+-
+-     i      average    bias      rms_error     stddev  ave_analyt_std
+----------------------------------------------------------------------
+-      0     0.0399     -0.0001      0.0013      0.0013     0.0012
+-      1     1.0626      0.0001      0.0114      0.0114     0.0109
+-      2     4.1113      0.0002      0.0260      0.0260     0.0257
+-      3     9.2565      0.0065      0.0472      0.0468     0.0493
+-      4    16.9905     -0.0095      0.1804      0.1801     0.1751
+-      5    25.9544     -0.0456      0.6175      0.6158     0.5718
+-Totals:    25.9544     -0.0456      0.6175      0.6158     0.5718
++INFO:pymbar.confidenceintervals:Error vs. alpha
++INFO:pymbar.confidenceintervals:alpha cheby      obs        obs err          normal           
++INFO:pymbar.confidenceintervals:  0.1 -99.000000   0.079035 (  0.064466,  0.094930)   0.079656
++INFO:pymbar.confidenceintervals:  0.2 -24.000000   0.155574 (  0.135644,  0.176589)   0.158519
++INFO:pymbar.confidenceintervals:  0.3 -10.111111   0.237937 (  0.214294,  0.262405)   0.235823
++INFO:pymbar.confidenceintervals:  0.4  -5.250000   0.306988 (  0.281234,  0.333351)   0.310843
++INFO:pymbar.confidenceintervals:  0.5  -3.000000   0.386023 (  0.358698,  0.413708)   0.382925
++INFO:pymbar.confidenceintervals:  0.6  -1.777778   0.437604 (  0.409674,  0.465731)   0.451494
++INFO:pymbar.confidenceintervals:  0.7  -1.040816   0.501664 (  0.473412,  0.529911)   0.516073
++INFO:pymbar.confidenceintervals:  0.8  -0.562500   0.562396 (  0.534269,  0.590326)   0.576289
++INFO:pymbar.confidenceintervals:  0.9  -0.234568   0.634775 (  0.607360,  0.661766)   0.631880
++INFO:pymbar.confidenceintervals:  1.0  -0.000000   0.682196 (  0.655603,  0.708215)   0.682689
++INFO:pymbar.confidenceintervals:  1.1   0.173554   0.727121 (  0.701599,  0.751928)   0.728668
++INFO:pymbar.confidenceintervals:  1.2   0.305556   0.766223 (  0.741894,  0.789713)   0.769861
++INFO:pymbar.confidenceintervals:  1.3   0.408284   0.797837 (  0.774681,  0.820055)   0.806399
++INFO:pymbar.confidenceintervals:  1.4   0.489796   0.830283 (  0.808558,  0.850966)   0.838487
++INFO:pymbar.confidenceintervals:  1.5   0.555556   0.864393 (  0.844481,  0.883156)   0.866386
++INFO:pymbar.confidenceintervals:  1.6   0.609375   0.882696 (  0.863920,  0.900265)   0.890401
++INFO:pymbar.confidenceintervals:  1.7   0.653979   0.898502 (  0.880821,  0.914928)   0.910869
++INFO:pymbar.confidenceintervals:  1.8   0.691358   0.915973 (  0.899654,  0.930982)   0.928139
++INFO:pymbar.confidenceintervals:  1.9   0.722992   0.942596 (  0.928770,  0.955027)   0.942567
++INFO:pymbar.confidenceintervals:  2.0   0.750000   0.955075 (  0.942672,  0.966045)   0.954500
++INFO:pymbar.confidenceintervals:  2.1   0.773243   0.965058 (  0.953971,  0.974682)   0.964271
++INFO:pymbar.confidenceintervals:  2.2   0.793388   0.969218 (  0.958742,  0.978218)   0.972193
++INFO:pymbar.confidenceintervals:  2.3   0.810964   0.976705 (  0.967459,  0.984453)   0.978552
++INFO:pymbar.confidenceintervals:  2.4   0.826389   0.982529 (  0.974398,  0.989144)   0.983605
++INFO:pymbar.confidenceintervals:  2.5   0.840000   0.985857 (  0.978455,  0.991733)   0.987581
++INFO:pymbar.confidenceintervals:  2.6   0.852071   0.990849 (  0.984741,  0.995419)   0.990678
++INFO:pymbar.confidenceintervals:  2.7   0.862826   0.993344 (  0.988028,  0.997120)   0.993066
++INFO:pymbar.confidenceintervals:  2.8   0.872449   0.995008 (  0.990311,  0.998164)   0.994890
++INFO:pymbar.confidenceintervals:  2.9   0.881094   0.996672 (  0.992718,  0.999092)   0.996268
++INFO:pymbar.confidenceintervals:  3.0   0.888889   0.997504 (  0.993998,  0.999485)   0.997300
++INFO:pymbar.confidenceintervals:  3.1   0.895942   0.998336 (  0.995370,  0.999798)   0.998065
++INFO:pymbar.confidenceintervals:  3.2   0.902344   0.998336 (  0.995370,  0.999798)   0.998626
++INFO:pymbar.confidenceintervals:  3.3   0.908173   0.999168 (  0.996933,  0.999979)   0.999033
++INFO:pymbar.confidenceintervals:  3.4   0.913495   0.999168 (  0.996933,  0.999979)   0.999326
++INFO:pymbar.confidenceintervals:  3.5   0.918367   0.999168 (  0.996933,  0.999979)   0.999535
++INFO:pymbar.confidenceintervals:  3.6   0.922840   0.999168 (  0.996933,  0.999979)   0.999682
++INFO:pymbar.confidenceintervals:  3.7   0.926954   0.999168 (  0.996933,  0.999979)   0.999784
++INFO:pymbar.confidenceintervals:  3.8   0.930748   0.999168 (  0.996933,  0.999979)   0.999855
++INFO:pymbar.confidenceintervals:  3.9   0.934254   0.999168 (  0.996933,  0.999979)   0.999904
++INFO:pymbar.confidenceintervals:  4.0   0.937500   0.999168 (  0.996933,  0.999979)   0.999937
++INFO:pymbar.confidenceintervals:
++INFO:pymbar.confidenceintervals:     i      average    bias      rms_error     stddev  ave_analyt_std
++INFO:pymbar.confidenceintervals:---------------------------------------------------------------------
++INFO:pymbar.confidenceintervals:      0     0.0400     -0.0000      0.0012      0.0012     0.0012
++INFO:pymbar.confidenceintervals:      1     1.0619     -0.0006      0.0111      0.0110     0.0109
++INFO:pymbar.confidenceintervals:      2     4.1114      0.0003      0.0266      0.0266     0.0257
++INFO:pymbar.confidenceintervals:      3     9.2475     -0.0025      0.0446      0.0446     0.0493
++INFO:pymbar.confidenceintervals:      4    16.9938     -0.0062      0.1791      0.1790     0.1752
++INFO:pymbar.confidenceintervals:      5    25.9694     -0.0306      0.5802      0.5794     0.5879
++INFO:pymbar.confidenceintervals:Totals:    25.9694     -0.0306      0.5802      0.5794     0.5879
+ Anderson-Darling Metrics (see README.md)
+-[  0.88636271   0.66578887   0.33607562   2.32717013   0.68941846
+-  12.15892596]
++[0.6901644  0.1987652  0.63184093 0.91454922 1.07566274 3.77360317]
+ 
+  ==== State 1 alone with MBAR ===== 
+-The uncertainty estimates are tested in this section.
++INFO:pymbar.confidenceintervals:The uncertainty estimates are tested in this section.
+ If the error is normally distributed, the actual error will be less than a
+ multiplier 'alpha' times the computed uncertainty 'sigma' a fraction of
+ time given by:
+@@ -1042,55 +1456,55 @@ A weak lower bound that holds regardless of how the error is distributed is give
+ by Chebyshev's inequality, and is listed as 'cheby' below.
+ Uncertainty estimates are tested for both free energy differences and expectations.
+ 
+-Error vs. alpha
+-alpha      cheby        obs          obs err            normal
+-  0.1 -99.000000   0.108911 (  0.069877,  0.155265)   0.079656
+-  0.2 -24.000000   0.153465 (  0.107260,  0.206163)   0.158519
+-  0.3 -10.111111   0.262376 (  0.204181,  0.325028)   0.235823
+-  0.4  -5.250000   0.336634 (  0.273241,  0.403090)   0.310843
+-  0.5  -3.000000   0.391089 (  0.325057,  0.459164)   0.382925
+-  0.6  -1.777778   0.475248 (  0.406855,  0.544104)   0.451494
+-  0.7  -1.040816   0.534653 (  0.465785,  0.602871)   0.516073
+-  0.8  -0.562500   0.589109 (  0.520668,  0.655878)   0.576289
+-  0.9  -0.234568   0.599010 (  0.530738,  0.665425)   0.631880
+-  1.0  -0.000000   0.623762 (  0.556038,  0.689165)   0.682689
+-  1.1   0.173554   0.648515 (  0.581525,  0.712719)   0.728668
+-  1.2   0.305556   0.698020 (  0.633092,  0.759233)   0.769861
+-  1.3   0.408284   0.742574 (  0.680251,  0.800349)   0.806399
+-  1.4   0.489796   0.792079 (  0.733624,  0.845059)   0.838487
+-  1.5   0.555556   0.826733 (  0.771728,  0.875614)   0.866386
+-  1.6   0.609375   0.881188 (  0.833262,  0.921978)   0.890401
+-  1.7   0.653979   0.891089 (  0.844735,  0.930123)   0.910869
+-  1.8   0.691358   0.905941 (  0.862162,  0.942125)   0.928139
+-  1.9   0.722992   0.930693 (  0.891940,  0.961400)   0.942567
+-  2.0   0.750000   0.945545 (  0.910411,  0.972368)   0.954500
+-  2.1   0.773243   0.960396 (  0.929565,  0.982663)   0.964271
+-  2.2   0.793388   0.965347 (  0.936163,  0.985886)   0.972193
+-  2.3   0.810964   0.970297 (  0.942906,  0.988968)   0.978552
+-  2.4   0.826389   0.970297 (  0.942906,  0.988968)   0.983605
+-  2.5   0.840000   0.975248 (  0.949833,  0.991875)   0.987581
+-  2.6   0.852071   0.995050 (  0.981815,  0.999874)   0.990678
+-  2.7   0.862826   0.995050 (  0.981815,  0.999874)   0.993066
+-  2.8   0.872449   0.995050 (  0.981815,  0.999874)   0.994890
+-  2.9   0.881094   0.995050 (  0.981815,  0.999874)   0.996268
+-  3.0   0.888889   0.995050 (  0.981815,  0.999874)   0.997300
+-  3.1   0.895942   0.995050 (  0.981815,  0.999874)   0.998065
+-  3.2   0.902344   0.995050 (  0.981815,  0.999874)   0.998626
+-  3.3   0.908173   0.995050 (  0.981815,  0.999874)   0.999033
+-  3.4   0.913495   0.995050 (  0.981815,  0.999874)   0.999326
+-  3.5   0.918367   0.995050 (  0.981815,  0.999874)   0.999535
+-  3.6   0.922840   0.995050 (  0.981815,  0.999874)   0.999682
+-  3.7   0.926954   0.995050 (  0.981815,  0.999874)   0.999784
+-  3.8   0.930748   0.995050 (  0.981815,  0.999874)   0.999855
+-  3.9   0.934254   0.995050 (  0.981815,  0.999874)   0.999904
+-  4.0   0.937500   0.995050 (  0.981815,  0.999874)   0.999937
+-
+-     i      average    bias      rms_error     stddev  ave_analyt_std
+----------------------------------------------------------------------
+-Totals:    -0.2149      0.0082      0.1620      0.1618     0.1554
++INFO:pymbar.confidenceintervals:Error vs. alpha
++INFO:pymbar.confidenceintervals:alpha cheby      obs        obs err          normal           
++INFO:pymbar.confidenceintervals:  0.1 -99.000000   0.064356 (  0.034884,  0.101964)   0.079656
++INFO:pymbar.confidenceintervals:  0.2 -24.000000   0.148515 (  0.103022,  0.200592)   0.158519
++INFO:pymbar.confidenceintervals:  0.3 -10.111111   0.227723 (  0.172689,  0.287861)   0.235823
++INFO:pymbar.confidenceintervals:  0.4  -5.250000   0.316832 (  0.254634,  0.382465)   0.310843
++INFO:pymbar.confidenceintervals:  0.5  -3.000000   0.391089 (  0.325057,  0.459164)   0.382925
++INFO:pymbar.confidenceintervals:  0.6  -1.777778   0.470297 (  0.401989,  0.539163)   0.451494
++INFO:pymbar.confidenceintervals:  0.7  -1.040816   0.509901 (  0.441113,  0.578503)   0.516073
++INFO:pymbar.confidenceintervals:  0.8  -0.562500   0.589109 (  0.520668,  0.655878)   0.576289
++INFO:pymbar.confidenceintervals:  0.9  -0.234568   0.658416 (  0.591774,  0.722087)   0.631880
++INFO:pymbar.confidenceintervals:  1.0  -0.000000   0.698020 (  0.633092,  0.759233)   0.682689
++INFO:pymbar.confidenceintervals:  1.1   0.173554   0.752475 (  0.690837,  0.809379)   0.728668
++INFO:pymbar.confidenceintervals:  1.2   0.305556   0.762376 (  0.701466,  0.818367)   0.769861
++INFO:pymbar.confidenceintervals:  1.3   0.408284   0.811881 (  0.755313,  0.862603)   0.806399
++INFO:pymbar.confidenceintervals:  1.4   0.489796   0.831683 (  0.777230,  0.879921)   0.838487
++INFO:pymbar.confidenceintervals:  1.5   0.555556   0.856436 (  0.804997,  0.901197)   0.866386
++INFO:pymbar.confidenceintervals:  1.6   0.609375   0.896040 (  0.850513,  0.934154)   0.890401
++INFO:pymbar.confidenceintervals:  1.7   0.653979   0.900990 (  0.856322,  0.938155)   0.910869
++INFO:pymbar.confidenceintervals:  1.8   0.691358   0.920792 (  0.879901,  0.953817)   0.928139
++INFO:pymbar.confidenceintervals:  1.9   0.722992   0.935644 (  0.898036,  0.965116)   0.942567
++INFO:pymbar.confidenceintervals:  2.0   0.750000   0.945545 (  0.910411,  0.972368)   0.954500
++INFO:pymbar.confidenceintervals:  2.1   0.773243   0.950495 (  0.916705,  0.975888)   0.964271
++INFO:pymbar.confidenceintervals:  2.2   0.793388   0.955446 (  0.923085,  0.979324)   0.972193
++INFO:pymbar.confidenceintervals:  2.3   0.810964   0.965347 (  0.936163,  0.985886)   0.978552
++INFO:pymbar.confidenceintervals:  2.4   0.826389   0.975248 (  0.949833,  0.991875)   0.983605
++INFO:pymbar.confidenceintervals:  2.5   0.840000   0.980198 (  0.957004,  0.994552)   0.987581
++INFO:pymbar.confidenceintervals:  2.6   0.852071   0.990099 (  0.972594,  0.998793)   0.990678
++INFO:pymbar.confidenceintervals:  2.7   0.862826   0.990099 (  0.972594,  0.998793)   0.993066
++INFO:pymbar.confidenceintervals:  2.8   0.872449   0.990099 (  0.972594,  0.998793)   0.994890
++INFO:pymbar.confidenceintervals:  2.9   0.881094   0.990099 (  0.972594,  0.998793)   0.996268
++INFO:pymbar.confidenceintervals:  3.0   0.888889   0.990099 (  0.972594,  0.998793)   0.997300
++INFO:pymbar.confidenceintervals:  3.1   0.895942   0.995050 (  0.981815,  0.999874)   0.998065
++INFO:pymbar.confidenceintervals:  3.2   0.902344   0.995050 (  0.981815,  0.999874)   0.998626
++INFO:pymbar.confidenceintervals:  3.3   0.908173   0.995050 (  0.981815,  0.999874)   0.999033
++INFO:pymbar.confidenceintervals:  3.4   0.913495   0.995050 (  0.981815,  0.999874)   0.999326
++INFO:pymbar.confidenceintervals:  3.5   0.918367   0.995050 (  0.981815,  0.999874)   0.999535
++INFO:pymbar.confidenceintervals:  3.6   0.922840   0.995050 (  0.981815,  0.999874)   0.999682
++INFO:pymbar.confidenceintervals:  3.7   0.926954   0.995050 (  0.981815,  0.999874)   0.999784
++INFO:pymbar.confidenceintervals:  3.8   0.930748   0.995050 (  0.981815,  0.999874)   0.999855
++INFO:pymbar.confidenceintervals:  3.9   0.934254   0.995050 (  0.981815,  0.999874)   0.999904
++INFO:pymbar.confidenceintervals:  4.0   0.937500   0.995050 (  0.981815,  0.999874)   0.999937
++INFO:pymbar.confidenceintervals:
++INFO:pymbar.confidenceintervals:     i      average    bias      rms_error     stddev  ave_analyt_std
++INFO:pymbar.confidenceintervals:---------------------------------------------------------------------
++INFO:pymbar.confidenceintervals:Totals:    -0.2184      0.0047      0.1547      0.1546     0.1551
+ 
+  ==== State 2 alone with MBAR ===== 
+-The uncertainty estimates are tested in this section.
++INFO:pymbar.confidenceintervals:The uncertainty estimates are tested in this section.
+ If the error is normally distributed, the actual error will be less than a
+ multiplier 'alpha' times the computed uncertainty 'sigma' a fraction of
+ time given by:
+@@ -1105,55 +1519,55 @@ A weak lower bound that holds regardless of how the error is distributed is give
+ by Chebyshev's inequality, and is listed as 'cheby' below.
+ Uncertainty estimates are tested for both free energy differences and expectations.
+ 
+-Error vs. alpha
+-alpha      cheby        obs          obs err            normal
+-  0.1 -99.000000   0.069307 (  0.038600,  0.108060)   0.079656
+-  0.2 -24.000000   0.148515 (  0.103022,  0.200592)   0.158519
+-  0.3 -10.111111   0.207921 (  0.154941,  0.266376)   0.235823
+-  0.4  -5.250000   0.272277 (  0.213271,  0.335554)   0.310843
+-  0.5  -3.000000   0.351485 (  0.287281,  0.418475)   0.382925
+-  0.6  -1.777778   0.415842 (  0.348906,  0.484356)   0.451494
+-  0.7  -1.040816   0.480198 (  0.411729,  0.549038)   0.516073
+-  0.8  -0.562500   0.549505 (  0.480671,  0.617411)   0.576289
+-  0.9  -0.234568   0.628713 (  0.561121,  0.693891)   0.631880
+-  1.0  -0.000000   0.663366 (  0.596910,  0.726759)   0.682689
+-  1.1   0.173554   0.712871 (  0.648728,  0.773022)   0.728668
+-  1.2   0.305556   0.742574 (  0.680251,  0.800349)   0.769861
+-  1.3   0.408284   0.772277 (  0.712139,  0.827311)   0.806399
+-  1.4   0.489796   0.811881 (  0.755313,  0.862603)   0.838487
+-  1.5   0.555556   0.831683 (  0.777230,  0.879921)   0.866386
+-  1.6   0.609375   0.856436 (  0.804997,  0.901197)   0.890401
+-  1.7   0.653979   0.891089 (  0.844735,  0.930123)   0.910869
+-  1.8   0.691358   0.915842 (  0.873949,  0.949958)   0.928139
+-  1.9   0.722992   0.935644 (  0.898036,  0.965116)   0.942567
+-  2.0   0.750000   0.940594 (  0.904191,  0.968774)   0.954500
+-  2.1   0.773243   0.950495 (  0.916705,  0.975888)   0.964271
+-  2.2   0.793388   0.955446 (  0.923085,  0.979324)   0.972193
+-  2.3   0.810964   0.970297 (  0.942906,  0.988968)   0.978552
+-  2.4   0.826389   0.970297 (  0.942906,  0.988968)   0.983605
+-  2.5   0.840000   0.975248 (  0.949833,  0.991875)   0.987581
+-  2.6   0.852071   0.980198 (  0.957004,  0.994552)   0.990678
+-  2.7   0.862826   0.990099 (  0.972594,  0.998793)   0.993066
+-  2.8   0.872449   0.995050 (  0.981815,  0.999874)   0.994890
+-  2.9   0.881094   0.995050 (  0.981815,  0.999874)   0.996268
+-  3.0   0.888889   0.995050 (  0.981815,  0.999874)   0.997300
+-  3.1   0.895942   0.995050 (  0.981815,  0.999874)   0.998065
+-  3.2   0.902344   0.995050 (  0.981815,  0.999874)   0.998626
+-  3.3   0.908173   0.995050 (  0.981815,  0.999874)   0.999033
+-  3.4   0.913495   0.995050 (  0.981815,  0.999874)   0.999326
+-  3.5   0.918367   0.995050 (  0.981815,  0.999874)   0.999535
+-  3.6   0.922840   0.995050 (  0.981815,  0.999874)   0.999682
+-  3.7   0.926954   0.995050 (  0.981815,  0.999874)   0.999784
+-  3.8   0.930748   0.995050 (  0.981815,  0.999874)   0.999855
+-  3.9   0.934254   0.995050 (  0.981815,  0.999874)   0.999904
+-  4.0   0.937500   0.995050 (  0.981815,  0.999874)   0.999937
+-
+-     i      average    bias      rms_error     stddev  ave_analyt_std
+----------------------------------------------------------------------
+-Totals:    -0.4987      0.0121      0.1856      0.1852     0.1768
++INFO:pymbar.confidenceintervals:Error vs. alpha
++INFO:pymbar.confidenceintervals:alpha cheby      obs        obs err          normal           
++INFO:pymbar.confidenceintervals:  0.1 -99.000000   0.064356 (  0.034884,  0.101964)   0.079656
++INFO:pymbar.confidenceintervals:  0.2 -24.000000   0.118812 (  0.078022,  0.166738)   0.158519
++INFO:pymbar.confidenceintervals:  0.3 -10.111111   0.202970 (  0.150535,  0.260973)   0.235823
++INFO:pymbar.confidenceintervals:  0.4  -5.250000   0.272277 (  0.213271,  0.335554)   0.310843
++INFO:pymbar.confidenceintervals:  0.5  -3.000000   0.361386 (  0.296680,  0.428692)   0.382925
++INFO:pymbar.confidenceintervals:  0.6  -1.777778   0.420792 (  0.353697,  0.489373)   0.451494
++INFO:pymbar.confidenceintervals:  0.7  -1.040816   0.475248 (  0.406855,  0.544104)   0.516073
++INFO:pymbar.confidenceintervals:  0.8  -0.562500   0.559406 (  0.490628,  0.627069)   0.576289
++INFO:pymbar.confidenceintervals:  0.9  -0.234568   0.618812 (  0.550964,  0.684431)   0.631880
++INFO:pymbar.confidenceintervals:  1.0  -0.000000   0.688119 (  0.622712,  0.749997)   0.682689
++INFO:pymbar.confidenceintervals:  1.1   0.173554   0.727723 (  0.664446,  0.786729)   0.728668
++INFO:pymbar.confidenceintervals:  1.2   0.305556   0.767327 (  0.706797,  0.822844)   0.769861
++INFO:pymbar.confidenceintervals:  1.3   0.408284   0.816832 (  0.760770,  0.866955)   0.806399
++INFO:pymbar.confidenceintervals:  1.4   0.489796   0.851485 (  0.799408,  0.896978)   0.838487
++INFO:pymbar.confidenceintervals:  1.5   0.555556   0.866337 (  0.816237,  0.909575)   0.866386
++INFO:pymbar.confidenceintervals:  1.6   0.609375   0.881188 (  0.833262,  0.921978)   0.890401
++INFO:pymbar.confidenceintervals:  1.7   0.653979   0.881188 (  0.833262,  0.921978)   0.910869
++INFO:pymbar.confidenceintervals:  1.8   0.691358   0.900990 (  0.856322,  0.938155)   0.928139
++INFO:pymbar.confidenceintervals:  1.9   0.722992   0.920792 (  0.879901,  0.953817)   0.942567
++INFO:pymbar.confidenceintervals:  2.0   0.750000   0.935644 (  0.898036,  0.965116)   0.954500
++INFO:pymbar.confidenceintervals:  2.1   0.773243   0.940594 (  0.904191,  0.968774)   0.964271
++INFO:pymbar.confidenceintervals:  2.2   0.793388   0.970297 (  0.942906,  0.988968)   0.972193
++INFO:pymbar.confidenceintervals:  2.3   0.810964   0.980198 (  0.957004,  0.994552)   0.978552
++INFO:pymbar.confidenceintervals:  2.4   0.826389   0.985149 (  0.964520,  0.996911)   0.983605
++INFO:pymbar.confidenceintervals:  2.5   0.840000   0.985149 (  0.964520,  0.996911)   0.987581
++INFO:pymbar.confidenceintervals:  2.6   0.852071   0.990099 (  0.972594,  0.998793)   0.990678
++INFO:pymbar.confidenceintervals:  2.7   0.862826   0.990099 (  0.972594,  0.998793)   0.993066
++INFO:pymbar.confidenceintervals:  2.8   0.872449   0.990099 (  0.972594,  0.998793)   0.994890
++INFO:pymbar.confidenceintervals:  2.9   0.881094   0.995050 (  0.981815,  0.999874)   0.996268
++INFO:pymbar.confidenceintervals:  3.0   0.888889   0.995050 (  0.981815,  0.999874)   0.997300
++INFO:pymbar.confidenceintervals:  3.1   0.895942   0.995050 (  0.981815,  0.999874)   0.998065
++INFO:pymbar.confidenceintervals:  3.2   0.902344   0.995050 (  0.981815,  0.999874)   0.998626
++INFO:pymbar.confidenceintervals:  3.3   0.908173   0.995050 (  0.981815,  0.999874)   0.999033
++INFO:pymbar.confidenceintervals:  3.4   0.913495   0.995050 (  0.981815,  0.999874)   0.999326
++INFO:pymbar.confidenceintervals:  3.5   0.918367   0.995050 (  0.981815,  0.999874)   0.999535
++INFO:pymbar.confidenceintervals:  3.6   0.922840   0.995050 (  0.981815,  0.999874)   0.999682
++INFO:pymbar.confidenceintervals:  3.7   0.926954   0.995050 (  0.981815,  0.999874)   0.999784
++INFO:pymbar.confidenceintervals:  3.8   0.930748   0.995050 (  0.981815,  0.999874)   0.999855
++INFO:pymbar.confidenceintervals:  3.9   0.934254   0.995050 (  0.981815,  0.999874)   0.999904
++INFO:pymbar.confidenceintervals:  4.0   0.937500   0.995050 (  0.981815,  0.999874)   0.999937
++INFO:pymbar.confidenceintervals:
++INFO:pymbar.confidenceintervals:     i      average    bias      rms_error     stddev  ave_analyt_std
++INFO:pymbar.confidenceintervals:---------------------------------------------------------------------
++INFO:pymbar.confidenceintervals:Totals:    -0.5048      0.0061      0.1802      0.1801     0.1765
+ 
+  ==== State 3 alone with MBAR ===== 
+-The uncertainty estimates are tested in this section.
++INFO:pymbar.confidenceintervals:The uncertainty estimates are tested in this section.
+ If the error is normally distributed, the actual error will be less than a
+ multiplier 'alpha' times the computed uncertainty 'sigma' a fraction of
+ time given by:
+@@ -1168,55 +1582,55 @@ A weak lower bound that holds regardless of how the error is distributed is give
+ by Chebyshev's inequality, and is listed as 'cheby' below.
+ Uncertainty estimates are tested for both free energy differences and expectations.
+ 
+-Error vs. alpha
+-alpha      cheby        obs          obs err            normal
+-  0.1 -99.000000   0.089109 (  0.053940,  0.131963)   0.079656
+-  0.2 -24.000000   0.183168 (  0.133045,  0.239230)   0.158519
+-  0.3 -10.111111   0.227723 (  0.172689,  0.287861)   0.235823
+-  0.4  -5.250000   0.277228 (  0.217831,  0.340803)   0.310843
+-  0.5  -3.000000   0.341584 (  0.277913,  0.408226)   0.382925
+-  0.6  -1.777778   0.396040 (  0.329813,  0.464217)   0.451494
+-  0.7  -1.040816   0.480198 (  0.411729,  0.549038)   0.516073
+-  0.8  -0.562500   0.544554 (  0.475702,  0.612571)   0.576289
+-  0.9  -0.234568   0.599010 (  0.530738,  0.665425)   0.631880
+-  1.0  -0.000000   0.633663 (  0.566210,  0.698609)   0.682689
+-  1.1   0.173554   0.688119 (  0.622712,  0.749997)   0.728668
+-  1.2   0.305556   0.757426 (  0.696146,  0.813878)   0.769861
+-  1.3   0.408284   0.797030 (  0.739027,  0.849465)   0.806399
+-  1.4   0.489796   0.831683 (  0.777230,  0.879921)   0.838487
+-  1.5   0.555556   0.861386 (  0.810607,  0.905396)   0.866386
+-  1.6   0.609375   0.881188 (  0.833262,  0.921978)   0.890401
+-  1.7   0.653979   0.896040 (  0.850513,  0.934154)   0.910869
+-  1.8   0.691358   0.925743 (  0.885897,  0.957632)   0.928139
+-  1.9   0.722992   0.935644 (  0.898036,  0.965116)   0.942567
+-  2.0   0.750000   0.945545 (  0.910411,  0.972368)   0.954500
+-  2.1   0.773243   0.945545 (  0.910411,  0.972368)   0.964271
+-  2.2   0.793388   0.950495 (  0.916705,  0.975888)   0.972193
+-  2.3   0.810964   0.960396 (  0.929565,  0.982663)   0.978552
+-  2.4   0.826389   0.965347 (  0.936163,  0.985886)   0.983605
+-  2.5   0.840000   0.975248 (  0.949833,  0.991875)   0.987581
+-  2.6   0.852071   0.980198 (  0.957004,  0.994552)   0.990678
+-  2.7   0.862826   0.985149 (  0.964520,  0.996911)   0.993066
+-  2.8   0.872449   0.990099 (  0.972594,  0.998793)   0.994890
+-  2.9   0.881094   0.990099 (  0.972594,  0.998793)   0.996268
+-  3.0   0.888889   0.995050 (  0.981815,  0.999874)   0.997300
+-  3.1   0.895942   0.995050 (  0.981815,  0.999874)   0.998065
+-  3.2   0.902344   0.995050 (  0.981815,  0.999874)   0.998626
+-  3.3   0.908173   0.995050 (  0.981815,  0.999874)   0.999033
+-  3.4   0.913495   0.995050 (  0.981815,  0.999874)   0.999326
+-  3.5   0.918367   0.995050 (  0.981815,  0.999874)   0.999535
+-  3.6   0.922840   0.995050 (  0.981815,  0.999874)   0.999682
+-  3.7   0.926954   0.995050 (  0.981815,  0.999874)   0.999784
+-  3.8   0.930748   0.995050 (  0.981815,  0.999874)   0.999855
+-  3.9   0.934254   0.995050 (  0.981815,  0.999874)   0.999904
+-  4.0   0.937500   0.995050 (  0.981815,  0.999874)   0.999937
+-
+-     i      average    bias      rms_error     stddev  ave_analyt_std
+----------------------------------------------------------------------
+-Totals:    -0.9060      0.0103      0.1902      0.1899     0.1825
++INFO:pymbar.confidenceintervals:Error vs. alpha
++INFO:pymbar.confidenceintervals:alpha cheby      obs        obs err          normal           
++INFO:pymbar.confidenceintervals:  0.1 -99.000000   0.059406 (  0.031226,  0.095809)   0.079656
++INFO:pymbar.confidenceintervals:  0.2 -24.000000   0.133663 (  0.090425,  0.183763)   0.158519
++INFO:pymbar.confidenceintervals:  0.3 -10.111111   0.227723 (  0.172689,  0.287861)   0.235823
++INFO:pymbar.confidenceintervals:  0.4  -5.250000   0.277228 (  0.217831,  0.340803)   0.310843
++INFO:pymbar.confidenceintervals:  0.5  -3.000000   0.351485 (  0.287281,  0.418475)   0.382925
++INFO:pymbar.confidenceintervals:  0.6  -1.777778   0.440594 (  0.372931,  0.509372)   0.451494
++INFO:pymbar.confidenceintervals:  0.7  -1.040816   0.534653 (  0.465785,  0.602871)   0.516073
++INFO:pymbar.confidenceintervals:  0.8  -0.562500   0.579208 (  0.510627,  0.646303)   0.576289
++INFO:pymbar.confidenceintervals:  0.9  -0.234568   0.613861 (  0.545896,  0.679691)   0.631880
++INFO:pymbar.confidenceintervals:  1.0  -0.000000   0.678218 (  0.612367,  0.740726)   0.682689
++INFO:pymbar.confidenceintervals:  1.1   0.173554   0.742574 (  0.680251,  0.800349)   0.728668
++INFO:pymbar.confidenceintervals:  1.2   0.305556   0.772277 (  0.712139,  0.827311)   0.769861
++INFO:pymbar.confidenceintervals:  1.3   0.408284   0.787129 (  0.728235,  0.840640)   0.806399
++INFO:pymbar.confidenceintervals:  1.4   0.489796   0.816832 (  0.760770,  0.866955)   0.838487
++INFO:pymbar.confidenceintervals:  1.5   0.555556   0.846535 (  0.793837,  0.892740)   0.866386
++INFO:pymbar.confidenceintervals:  1.6   0.609375   0.886139 (  0.838985,  0.926064)   0.890401
++INFO:pymbar.confidenceintervals:  1.7   0.653979   0.905941 (  0.862162,  0.942125)   0.910869
++INFO:pymbar.confidenceintervals:  1.8   0.691358   0.910891 (  0.868037,  0.946060)   0.928139
++INFO:pymbar.confidenceintervals:  1.9   0.722992   0.925743 (  0.885897,  0.957632)   0.942567
++INFO:pymbar.confidenceintervals:  2.0   0.750000   0.945545 (  0.910411,  0.972368)   0.954500
++INFO:pymbar.confidenceintervals:  2.1   0.773243   0.955446 (  0.923085,  0.979324)   0.964271
++INFO:pymbar.confidenceintervals:  2.2   0.793388   0.960396 (  0.929565,  0.982663)   0.972193
++INFO:pymbar.confidenceintervals:  2.3   0.810964   0.980198 (  0.957004,  0.994552)   0.978552
++INFO:pymbar.confidenceintervals:  2.4   0.826389   0.985149 (  0.964520,  0.996911)   0.983605
++INFO:pymbar.confidenceintervals:  2.5   0.840000   0.985149 (  0.964520,  0.996911)   0.987581
++INFO:pymbar.confidenceintervals:  2.6   0.852071   0.985149 (  0.964520,  0.996911)   0.990678
++INFO:pymbar.confidenceintervals:  2.7   0.862826   0.990099 (  0.972594,  0.998793)   0.993066
++INFO:pymbar.confidenceintervals:  2.8   0.872449   0.990099 (  0.972594,  0.998793)   0.994890
++INFO:pymbar.confidenceintervals:  2.9   0.881094   0.995050 (  0.981815,  0.999874)   0.996268
++INFO:pymbar.confidenceintervals:  3.0   0.888889   0.995050 (  0.981815,  0.999874)   0.997300
++INFO:pymbar.confidenceintervals:  3.1   0.895942   0.995050 (  0.981815,  0.999874)   0.998065
++INFO:pymbar.confidenceintervals:  3.2   0.902344   0.995050 (  0.981815,  0.999874)   0.998626
++INFO:pymbar.confidenceintervals:  3.3   0.908173   0.995050 (  0.981815,  0.999874)   0.999033
++INFO:pymbar.confidenceintervals:  3.4   0.913495   0.995050 (  0.981815,  0.999874)   0.999326
++INFO:pymbar.confidenceintervals:  3.5   0.918367   0.995050 (  0.981815,  0.999874)   0.999535
++INFO:pymbar.confidenceintervals:  3.6   0.922840   0.995050 (  0.981815,  0.999874)   0.999682
++INFO:pymbar.confidenceintervals:  3.7   0.926954   0.995050 (  0.981815,  0.999874)   0.999784
++INFO:pymbar.confidenceintervals:  3.8   0.930748   0.995050 (  0.981815,  0.999874)   0.999855
++INFO:pymbar.confidenceintervals:  3.9   0.934254   0.995050 (  0.981815,  0.999874)   0.999904
++INFO:pymbar.confidenceintervals:  4.0   0.937500   0.995050 (  0.981815,  0.999874)   0.999937
++INFO:pymbar.confidenceintervals:
++INFO:pymbar.confidenceintervals:     i      average    bias      rms_error     stddev  ave_analyt_std
++INFO:pymbar.confidenceintervals:---------------------------------------------------------------------
++INFO:pymbar.confidenceintervals:Totals:    -0.9105      0.0058      0.1841      0.1840     0.1822
+ 
+  ==== State 4 alone with MBAR ===== 
+-The uncertainty estimates are tested in this section.
++INFO:pymbar.confidenceintervals:The uncertainty estimates are tested in this section.
+ If the error is normally distributed, the actual error will be less than a
+ multiplier 'alpha' times the computed uncertainty 'sigma' a fraction of
+ time given by:
+@@ -1231,55 +1645,55 @@ A weak lower bound that holds regardless of how the error is distributed is give
+ by Chebyshev's inequality, and is listed as 'cheby' below.
+ Uncertainty estimates are tested for both free energy differences and expectations.
+ 
+-Error vs. alpha
+-alpha      cheby        obs          obs err            normal
+-  0.1 -99.000000   0.089109 (  0.053940,  0.131963)   0.079656
+-  0.2 -24.000000   0.158416 (  0.111516,  0.211716)   0.158519
+-  0.3 -10.111111   0.222772 (  0.168234,  0.282508)   0.235823
+-  0.4  -5.250000   0.282178 (  0.222400,  0.346042)   0.310843
+-  0.5  -3.000000   0.336634 (  0.273241,  0.403090)   0.382925
+-  0.6  -1.777778   0.415842 (  0.348906,  0.484356)   0.451494
+-  0.7  -1.040816   0.480198 (  0.411729,  0.549038)   0.516073
+-  0.8  -0.562500   0.534653 (  0.465785,  0.602871)   0.576289
+-  0.9  -0.234568   0.613861 (  0.545896,  0.679691)   0.631880
+-  1.0  -0.000000   0.658416 (  0.591774,  0.722087)   0.682689
+-  1.1   0.173554   0.688119 (  0.622712,  0.749997)   0.728668
+-  1.2   0.305556   0.752475 (  0.690837,  0.809379)   0.769861
+-  1.3   0.408284   0.811881 (  0.755313,  0.862603)   0.806399
+-  1.4   0.489796   0.836634 (  0.782749,  0.884211)   0.838487
+-  1.5   0.555556   0.866337 (  0.816237,  0.909575)   0.866386
+-  1.6   0.609375   0.886139 (  0.838985,  0.926064)   0.890401
+-  1.7   0.653979   0.910891 (  0.868037,  0.946060)   0.910869
+-  1.8   0.691358   0.910891 (  0.868037,  0.946060)   0.928139
+-  1.9   0.722992   0.925743 (  0.885897,  0.957632)   0.942567
+-  2.0   0.750000   0.930693 (  0.891940,  0.961400)   0.954500
+-  2.1   0.773243   0.945545 (  0.910411,  0.972368)   0.964271
+-  2.2   0.793388   0.950495 (  0.916705,  0.975888)   0.972193
+-  2.3   0.810964   0.960396 (  0.929565,  0.982663)   0.978552
+-  2.4   0.826389   0.965347 (  0.936163,  0.985886)   0.983605
+-  2.5   0.840000   0.970297 (  0.942906,  0.988968)   0.987581
+-  2.6   0.852071   0.985149 (  0.964520,  0.996911)   0.990678
+-  2.7   0.862826   0.990099 (  0.972594,  0.998793)   0.993066
+-  2.8   0.872449   0.995050 (  0.981815,  0.999874)   0.994890
+-  2.9   0.881094   0.995050 (  0.981815,  0.999874)   0.996268
+-  3.0   0.888889   0.995050 (  0.981815,  0.999874)   0.997300
+-  3.1   0.895942   0.995050 (  0.981815,  0.999874)   0.998065
+-  3.2   0.902344   0.995050 (  0.981815,  0.999874)   0.998626
+-  3.3   0.908173   0.995050 (  0.981815,  0.999874)   0.999033
+-  3.4   0.913495   0.995050 (  0.981815,  0.999874)   0.999326
+-  3.5   0.918367   0.995050 (  0.981815,  0.999874)   0.999535
+-  3.6   0.922840   0.995050 (  0.981815,  0.999874)   0.999682
+-  3.7   0.926954   0.995050 (  0.981815,  0.999874)   0.999784
+-  3.8   0.930748   0.995050 (  0.981815,  0.999874)   0.999855
+-  3.9   0.934254   0.995050 (  0.981815,  0.999874)   0.999904
+-  4.0   0.937500   0.995050 (  0.981815,  0.999874)   0.999937
+-
+-     i      average    bias      rms_error     stddev  ave_analyt_std
+----------------------------------------------------------------------
+-Totals:    -1.5992      0.0102      0.1917      0.1915     0.1838
++INFO:pymbar.confidenceintervals:Error vs. alpha
++INFO:pymbar.confidenceintervals:alpha cheby      obs        obs err          normal           
++INFO:pymbar.confidenceintervals:  0.1 -99.000000   0.084158 (  0.050042,  0.126051)   0.079656
++INFO:pymbar.confidenceintervals:  0.2 -24.000000   0.148515 (  0.103022,  0.200592)   0.158519
++INFO:pymbar.confidenceintervals:  0.3 -10.111111   0.242574 (  0.186122,  0.303854)   0.235823
++INFO:pymbar.confidenceintervals:  0.4  -5.250000   0.306931 (  0.245381,  0.372102)   0.310843
++INFO:pymbar.confidenceintervals:  0.5  -3.000000   0.371287 (  0.306109,  0.438879)   0.382925
++INFO:pymbar.confidenceintervals:  0.6  -1.777778   0.440594 (  0.372931,  0.509372)   0.451494
++INFO:pymbar.confidenceintervals:  0.7  -1.040816   0.509901 (  0.441113,  0.578503)   0.516073
++INFO:pymbar.confidenceintervals:  0.8  -0.562500   0.574257 (  0.505617,  0.641505)   0.576289
++INFO:pymbar.confidenceintervals:  0.9  -0.234568   0.623762 (  0.556038,  0.689165)   0.631880
++INFO:pymbar.confidenceintervals:  1.0  -0.000000   0.693069 (  0.627898,  0.754619)   0.682689
++INFO:pymbar.confidenceintervals:  1.1   0.173554   0.747525 (  0.685539,  0.804869)   0.728668
++INFO:pymbar.confidenceintervals:  1.2   0.305556   0.767327 (  0.706797,  0.822844)   0.769861
++INFO:pymbar.confidenceintervals:  1.3   0.408284   0.811881 (  0.755313,  0.862603)   0.806399
++INFO:pymbar.confidenceintervals:  1.4   0.489796   0.821782 (  0.766242,  0.871292)   0.838487
++INFO:pymbar.confidenceintervals:  1.5   0.555556   0.861386 (  0.810607,  0.905396)   0.866386
++INFO:pymbar.confidenceintervals:  1.6   0.609375   0.876238 (  0.827563,  0.917867)   0.890401
++INFO:pymbar.confidenceintervals:  1.7   0.653979   0.881188 (  0.833262,  0.921978)   0.910869
++INFO:pymbar.confidenceintervals:  1.8   0.691358   0.910891 (  0.868037,  0.946060)   0.928139
++INFO:pymbar.confidenceintervals:  1.9   0.722992   0.930693 (  0.891940,  0.961400)   0.942567
++INFO:pymbar.confidenceintervals:  2.0   0.750000   0.945545 (  0.910411,  0.972368)   0.954500
++INFO:pymbar.confidenceintervals:  2.1   0.773243   0.960396 (  0.929565,  0.982663)   0.964271
++INFO:pymbar.confidenceintervals:  2.2   0.793388   0.970297 (  0.942906,  0.988968)   0.972193
++INFO:pymbar.confidenceintervals:  2.3   0.810964   0.975248 (  0.949833,  0.991875)   0.978552
++INFO:pymbar.confidenceintervals:  2.4   0.826389   0.985149 (  0.964520,  0.996911)   0.983605
++INFO:pymbar.confidenceintervals:  2.5   0.840000   0.985149 (  0.964520,  0.996911)   0.987581
++INFO:pymbar.confidenceintervals:  2.6   0.852071   0.990099 (  0.972594,  0.998793)   0.990678
++INFO:pymbar.confidenceintervals:  2.7   0.862826   0.990099 (  0.972594,  0.998793)   0.993066
++INFO:pymbar.confidenceintervals:  2.8   0.872449   0.990099 (  0.972594,  0.998793)   0.994890
++INFO:pymbar.confidenceintervals:  2.9   0.881094   0.990099 (  0.972594,  0.998793)   0.996268
++INFO:pymbar.confidenceintervals:  3.0   0.888889   0.995050 (  0.981815,  0.999874)   0.997300
++INFO:pymbar.confidenceintervals:  3.1   0.895942   0.995050 (  0.981815,  0.999874)   0.998065
++INFO:pymbar.confidenceintervals:  3.2   0.902344   0.995050 (  0.981815,  0.999874)   0.998626
++INFO:pymbar.confidenceintervals:  3.3   0.908173   0.995050 (  0.981815,  0.999874)   0.999033
++INFO:pymbar.confidenceintervals:  3.4   0.913495   0.995050 (  0.981815,  0.999874)   0.999326
++INFO:pymbar.confidenceintervals:  3.5   0.918367   0.995050 (  0.981815,  0.999874)   0.999535
++INFO:pymbar.confidenceintervals:  3.6   0.922840   0.995050 (  0.981815,  0.999874)   0.999682
++INFO:pymbar.confidenceintervals:  3.7   0.926954   0.995050 (  0.981815,  0.999874)   0.999784
++INFO:pymbar.confidenceintervals:  3.8   0.930748   0.995050 (  0.981815,  0.999874)   0.999855
++INFO:pymbar.confidenceintervals:  3.9   0.934254   0.995050 (  0.981815,  0.999874)   0.999904
++INFO:pymbar.confidenceintervals:  4.0   0.937500   0.995050 (  0.981815,  0.999874)   0.999937
++INFO:pymbar.confidenceintervals:
++INFO:pymbar.confidenceintervals:     i      average    bias      rms_error     stddev  ave_analyt_std
++INFO:pymbar.confidenceintervals:---------------------------------------------------------------------
++INFO:pymbar.confidenceintervals:Totals:    -1.6024      0.0070      0.1840      0.1839     0.1835
+ 
+  ==== State 5 alone with MBAR ===== 
+-The uncertainty estimates are tested in this section.
++INFO:pymbar.confidenceintervals:The uncertainty estimates are tested in this section.
+ If the error is normally distributed, the actual error will be less than a
+ multiplier 'alpha' times the computed uncertainty 'sigma' a fraction of
+ time given by:
+@@ -1294,49 +1708,49 @@ A weak lower bound that holds regardless of how the error is distributed is give
+ by Chebyshev's inequality, and is listed as 'cheby' below.
+ Uncertainty estimates are tested for both free energy differences and expectations.
+ 
+-Error vs. alpha
+-alpha      cheby        obs          obs err            normal
+-  0.1 -99.000000   0.079208 (  0.046183,  0.120099)   0.079656
+-  0.2 -24.000000   0.118812 (  0.078022,  0.166738)   0.158519
+-  0.3 -10.111111   0.207921 (  0.154941,  0.266376)   0.235823
+-  0.4  -5.250000   0.277228 (  0.217831,  0.340803)   0.310843
+-  0.5  -3.000000   0.331683 (  0.268577,  0.397946)   0.382925
+-  0.6  -1.777778   0.410891 (  0.344122,  0.479332)   0.451494
+-  0.7  -1.040816   0.495050 (  0.426391,  0.563801)   0.516073
+-  0.8  -0.562500   0.534653 (  0.465785,  0.602871)   0.576289
+-  0.9  -0.234568   0.608911 (  0.540836,  0.674943)   0.631880
+-  1.0  -0.000000   0.678218 (  0.612367,  0.740726)   0.682689
+-  1.1   0.173554   0.707921 (  0.643507,  0.768435)   0.728668
+-  1.2   0.305556   0.752475 (  0.690837,  0.809379)   0.769861
+-  1.3   0.408284   0.801980 (  0.744442,  0.853858)   0.806399
+-  1.4   0.489796   0.841584 (  0.788284,  0.888484)   0.838487
+-  1.5   0.555556   0.856436 (  0.804997,  0.901197)   0.866386
+-  1.6   0.609375   0.876238 (  0.827563,  0.917867)   0.890401
+-  1.7   0.653979   0.891089 (  0.844735,  0.930123)   0.910869
+-  1.8   0.691358   0.905941 (  0.862162,  0.942125)   0.928139
+-  1.9   0.722992   0.915842 (  0.873949,  0.949958)   0.942567
+-  2.0   0.750000   0.940594 (  0.904191,  0.968774)   0.954500
+-  2.1   0.773243   0.950495 (  0.916705,  0.975888)   0.964271
+-  2.2   0.793388   0.960396 (  0.929565,  0.982663)   0.972193
+-  2.3   0.810964   0.960396 (  0.929565,  0.982663)   0.978552
+-  2.4   0.826389   0.980198 (  0.957004,  0.994552)   0.983605
+-  2.5   0.840000   0.990099 (  0.972594,  0.998793)   0.987581
+-  2.6   0.852071   0.995050 (  0.981815,  0.999874)   0.990678
+-  2.7   0.862826   0.995050 (  0.981815,  0.999874)   0.993066
+-  2.8   0.872449   0.995050 (  0.981815,  0.999874)   0.994890
+-  2.9   0.881094   0.995050 (  0.981815,  0.999874)   0.996268
+-  3.0   0.888889   0.995050 (  0.981815,  0.999874)   0.997300
+-  3.1   0.895942   0.995050 (  0.981815,  0.999874)   0.998065
+-  3.2   0.902344   0.995050 (  0.981815,  0.999874)   0.998626
+-  3.3   0.908173   0.995050 (  0.981815,  0.999874)   0.999033
+-  3.4   0.913495   0.995050 (  0.981815,  0.999874)   0.999326
+-  3.5   0.918367   0.995050 (  0.981815,  0.999874)   0.999535
+-  3.6   0.922840   0.995050 (  0.981815,  0.999874)   0.999682
+-  3.7   0.926954   0.995050 (  0.981815,  0.999874)   0.999784
+-  3.8   0.930748   0.995050 (  0.981815,  0.999874)   0.999855
+-  3.9   0.934254   0.995050 (  0.981815,  0.999874)   0.999904
+-  4.0   0.937500   0.995050 (  0.981815,  0.999874)   0.999937
+-
+-     i      average    bias      rms_error     stddev  ave_analyt_std
+----------------------------------------------------------------------
+-Totals:    -1.5971      0.0123      0.1935      0.1931     0.1881
++INFO:pymbar.confidenceintervals:Error vs. alpha
++INFO:pymbar.confidenceintervals:alpha cheby      obs        obs err          normal           
++INFO:pymbar.confidenceintervals:  0.1 -99.000000   0.108911 (  0.069877,  0.155265)   0.079656
++INFO:pymbar.confidenceintervals:  0.2 -24.000000   0.158416 (  0.111516,  0.211716)   0.158519
++INFO:pymbar.confidenceintervals:  0.3 -10.111111   0.232673 (  0.177156,  0.293203)   0.235823
++INFO:pymbar.confidenceintervals:  0.4  -5.250000   0.301980 (  0.240767,  0.366908)   0.310843
++INFO:pymbar.confidenceintervals:  0.5  -3.000000   0.386139 (  0.320309,  0.454104)   0.382925
++INFO:pymbar.confidenceintervals:  0.6  -1.777778   0.450495 (  0.382589,  0.519329)   0.451494
++INFO:pymbar.confidenceintervals:  0.7  -1.040816   0.519802 (  0.450962,  0.588271)   0.516073
++INFO:pymbar.confidenceintervals:  0.8  -0.562500   0.579208 (  0.510627,  0.646303)   0.576289
++INFO:pymbar.confidenceintervals:  0.9  -0.234568   0.638614 (  0.571308,  0.703320)   0.631880
++INFO:pymbar.confidenceintervals:  1.0  -0.000000   0.698020 (  0.633092,  0.759233)   0.682689
++INFO:pymbar.confidenceintervals:  1.1   0.173554   0.747525 (  0.685539,  0.804869)   0.728668
++INFO:pymbar.confidenceintervals:  1.2   0.305556   0.787129 (  0.728235,  0.840640)   0.769861
++INFO:pymbar.confidenceintervals:  1.3   0.408284   0.816832 (  0.760770,  0.866955)   0.806399
++INFO:pymbar.confidenceintervals:  1.4   0.489796   0.836634 (  0.782749,  0.884211)   0.838487
++INFO:pymbar.confidenceintervals:  1.5   0.555556   0.851485 (  0.799408,  0.896978)   0.866386
++INFO:pymbar.confidenceintervals:  1.6   0.609375   0.871287 (  0.821889,  0.913732)   0.890401
++INFO:pymbar.confidenceintervals:  1.7   0.653979   0.876238 (  0.827563,  0.917867)   0.910869
++INFO:pymbar.confidenceintervals:  1.8   0.691358   0.896040 (  0.850513,  0.934154)   0.928139
++INFO:pymbar.confidenceintervals:  1.9   0.722992   0.915842 (  0.873949,  0.949958)   0.942567
++INFO:pymbar.confidenceintervals:  2.0   0.750000   0.940594 (  0.904191,  0.968774)   0.954500
++INFO:pymbar.confidenceintervals:  2.1   0.773243   0.965347 (  0.936163,  0.985886)   0.964271
++INFO:pymbar.confidenceintervals:  2.2   0.793388   0.980198 (  0.957004,  0.994552)   0.972193
++INFO:pymbar.confidenceintervals:  2.3   0.810964   0.980198 (  0.957004,  0.994552)   0.978552
++INFO:pymbar.confidenceintervals:  2.4   0.826389   0.980198 (  0.957004,  0.994552)   0.983605
++INFO:pymbar.confidenceintervals:  2.5   0.840000   0.980198 (  0.957004,  0.994552)   0.987581
++INFO:pymbar.confidenceintervals:  2.6   0.852071   0.985149 (  0.964520,  0.996911)   0.990678
++INFO:pymbar.confidenceintervals:  2.7   0.862826   0.985149 (  0.964520,  0.996911)   0.993066
++INFO:pymbar.confidenceintervals:  2.8   0.872449   0.990099 (  0.972594,  0.998793)   0.994890
++INFO:pymbar.confidenceintervals:  2.9   0.881094   0.995050 (  0.981815,  0.999874)   0.996268
++INFO:pymbar.confidenceintervals:  3.0   0.888889   0.995050 (  0.981815,  0.999874)   0.997300
++INFO:pymbar.confidenceintervals:  3.1   0.895942   0.995050 (  0.981815,  0.999874)   0.998065
++INFO:pymbar.confidenceintervals:  3.2   0.902344   0.995050 (  0.981815,  0.999874)   0.998626
++INFO:pymbar.confidenceintervals:  3.3   0.908173   0.995050 (  0.981815,  0.999874)   0.999033
++INFO:pymbar.confidenceintervals:  3.4   0.913495   0.995050 (  0.981815,  0.999874)   0.999326
++INFO:pymbar.confidenceintervals:  3.5   0.918367   0.995050 (  0.981815,  0.999874)   0.999535
++INFO:pymbar.confidenceintervals:  3.6   0.922840   0.995050 (  0.981815,  0.999874)   0.999682
++INFO:pymbar.confidenceintervals:  3.7   0.926954   0.995050 (  0.981815,  0.999874)   0.999784
++INFO:pymbar.confidenceintervals:  3.8   0.930748   0.995050 (  0.981815,  0.999874)   0.999855
++INFO:pymbar.confidenceintervals:  3.9   0.934254   0.995050 (  0.981815,  0.999874)   0.999904
++INFO:pymbar.confidenceintervals:  4.0   0.937500   0.995050 (  0.981815,  0.999874)   0.999937
++INFO:pymbar.confidenceintervals:
++INFO:pymbar.confidenceintervals:     i      average    bias      rms_error     stddev  ave_analyt_std
++INFO:pymbar.confidenceintervals:---------------------------------------------------------------------
++INFO:pymbar.confidenceintervals:Totals:    -1.6010      0.0084      0.1885      0.1883     0.1879
+diff --git a/examples/harmonic-oscillators/harmonic-oscillators.py b/examples/harmonic-oscillators/harmonic-oscillators.py
+index 2d692a19..4c0ee372 100644
+--- a/examples/harmonic-oscillators/harmonic-oscillators.py
++++ b/examples/harmonic-oscillators/harmonic-oscillators.py
+@@ -26,6 +26,11 @@
+ from pymbar import testsystems, exp, exp_gauss, bar, MBAR, FES
+ from pymbar.utils import ParameterError
+ 
++import logging
++import sys
++
++logging.basicConfig(stream=sys.stdout, level=logging.INFO)
++
+ # =============================================================================================
+ # HELPER FUNCTIONS
+ # =============================================================================================
+@@ -219,7 +224,7 @@ def get_analytical(beta, K, O, observables):
+ for k in range(1, K):
+     if N_k[k] != 0:
+         w_R = u_kln[k, k - 1, 0 : N_k[k]] - u_kln[k, k, 0 : N_k[k]]  # reverse work
+-        df_exp, ddf_exp = exp(w_R)
++        results = exp(w_R)
+         df_exp = -results["Delta_f"]
+         ddf_exp = results["dDelta_f"]
+         exp_analytical = f_k_analytical[k] - f_k_analytical[k - 1]
+@@ -805,7 +810,7 @@ def generate_fes_data(
+ # Compute fre energy profile, first with histograms
+ print("Solving for free energies of state to initialize free energy profile...")
+ mbar_options = dict()
+-mbar_options["verbose"] = True
++mbar_options["verbose"] = False
+ fes = FES(u_kn, N_k, mbar_options=mbar_options)
+ print("Computing free energy profile ...")
+ histogram_parameters = dict()
+diff --git a/examples/harmonic-oscillators/harmonic-oscillators.py_output.txt b/examples/harmonic-oscillators/harmonic-oscillators.py_output.txt
+index 5765e48b..81635d69 100644
+--- a/examples/harmonic-oscillators/harmonic-oscillators.py_output.txt
++++ b/examples/harmonic-oscillators/harmonic-oscillators.py_output.txt
+@@ -1,48 +1,42 @@
+ Computing dimensionless free energies analytically...
+ This script will draw samples from 6 harmonic oscillators.
+-The harmonic oscillators have equilibrium positions
+-[0 1 2 3 4 5]
+-and spring constants
+-[25 16  9  4  1  1]
+-and the following number of samples will be drawn from each (can be zero if no samples drawn):
+-[10000 10000 10000 10000     0 10000]
+-
++The harmonic oscillators have equilibrium positions: [0 1 2 3 4 5]
++and spring constants: [25 16  9  4  1  1]
++and the following number of samples will be drawn from each (can be zero if no samples drawn): [10000 10000 10000 10000     0 10000]
+ generating samples...
+ ======================================
+-      Initializing MBAR
++      Initializing MBAR               
+ ======================================
+ Estimating relative free energies from simulation (this may take a while)...
+-K (total states) = 6, total samples = 50000
+-N_k =
+-[10000 10000 10000 10000     0 10000]
+-There are 5 states with samples.
+-Initializing free energies to zero.
+-Initial dimensionless free energies with method zeros
+-f_k =
+-[ 0.  0.  0.  0.  0.  0.]
+-Determining dimensionless free energies by Newton-Raphson / self-consistent iteration.
+-self consistent iteration gradient norm is 9.7464e+05, Newton-Raphson gradient norm is      22996
+-Choosing self-consistent iteration on iteration 0
+-self consistent iteration gradient norm is 6.5206e+05, Newton-Raphson gradient norm is      10294
+-Choosing self-consistent iteration for lower gradient on iteration 1
+-self consistent iteration gradient norm is 4.5608e+05, Newton-Raphson gradient norm is     4961.3
+-Newton-Raphson used on iteration 2
+-self consistent iteration gradient norm is     3170.1, Newton-Raphson gradient norm is    0.42264
+-Newton-Raphson used on iteration 3
+-self consistent iteration gradient norm is    0.23362, Newton-Raphson gradient norm is 2.3376e-09
+-Newton-Raphson used on iteration 4
+-self consistent iteration gradient norm is 1.2212e-09, Newton-Raphson gradient norm is 1.2449e-22
+-Newton-Raphson used on iteration 5
+-self consistent iteration gradient norm is          0, Newton-Raphson gradient norm is 1.4421e-22
+-Choosing self-consistent iteration for lower gradient on iteration 6
+-Converged to tolerance of 3.405346e-15 in 7 iterations.
+-Of 7 iterations, 4 were Newton-Raphson iterations and 3 were self-consistent iterations
+-Final dimensionless free energies
+-f_k =
+-[ 0.         -0.22821647 -0.49856217 -0.89211081 -1.57434696 -1.57231022]
+-MBAR initialization complete.
++INFO:pymbar.mbar:K (total states) = 6, total samples = 50000
++INFO:pymbar.mbar:N_k = 
++INFO:pymbar.mbar:[10000 10000 10000 10000     0 10000]
++INFO:pymbar.mbar:There are 5 states with samples.
++INFO:pymbar.mbar:Initializing free energies to zero.
++INFO:pymbar.mbar:Initial dimensionless free energies with method zeros
++INFO:pymbar.mbar:f_k = 
++INFO:pymbar.mbar:[0. 0. 0. 0. 0. 0.]
++WARNING:pymbar.mbar_solvers:
++******* JAX 64-bit mode is now on! *******
++*     JAX is now set to 64-bit mode!     *
++*   This MAY cause problems with other   *
++*      uses of JAX in the same code.     *
++******************************************
++
++INFO:absl:Remote TPU is not linked into jax; skipping remote TPU.
++INFO:absl:Unable to initialize backend 'tpu_driver': Could not initialize backend 'tpu_driver'
++INFO:absl:Unable to initialize backend 'cuda': module 'jaxlib.xla_extension' has no attribute 'GpuAllocatorConfig'
++INFO:absl:Unable to initialize backend 'rocm': module 'jaxlib.xla_extension' has no attribute 'GpuAllocatorConfig'
++INFO:absl:Unable to initialize backend 'tpu': module 'jaxlib.xla_extension' has no attribute 'get_tpu_client'
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.22e-11
++INFO:pymbar.mbar:Final dimensionless free energies
++INFO:pymbar.mbar:f_k = 
++INFO:pymbar.mbar:[ 0.         -0.22821647 -0.49856217 -0.89211081 -1.57434696 -1.57231022]
++INFO:pymbar.mbar:MBAR initialization complete.
+ =============================================
+-      Testing compute_free_energy_differences
++      Testing compute_free_energy_differences       
+ =============================================
+ Error in free energies is:
+ [[ 0.         -0.00507292  0.01226345  0.02417993  0.03509095  0.03712769]
+@@ -52,21 +46,21 @@ Error in free energies is:
+  [-0.03509095 -0.04016388 -0.0228275  -0.01091103  0.          0.00203674]
+  [-0.03712769 -0.04220061 -0.02486424 -0.01294776 -0.00203674  0.        ]]
+ Uncertainty in free energies is:
+-[[ 0.          0.07100713  0.08109591  0.08450777  0.08621464  0.08859106]
+- [ 0.07100713  0.          0.03654687  0.04359901  0.04684609  0.05106776]
+- [ 0.08109591  0.03654687  0.          0.01988063  0.02659403  0.03325712]
+- [ 0.08450777  0.04359901  0.01988063  0.          0.0150578   0.02393041]
+- [ 0.08621464  0.04684609  0.02659403  0.0150578   0.          0.01018445]
+- [ 0.08859106  0.05106776  0.03325712  0.02393041  0.01018445  0.        ]]
++[[0.         0.07100713 0.08109591 0.08450777 0.08621464 0.08859106]
++ [0.07100713 0.         0.03654687 0.04359901 0.04684609 0.05106776]
++ [0.08109591 0.03654687 0.         0.01988063 0.02659403 0.03325712]
++ [0.08450777 0.04359901 0.01988063 0.         0.0150578  0.02393041]
++ [0.08621464 0.04684609 0.02659403 0.0150578  0.         0.01018445]
++ [0.08859106 0.05106776 0.03325712 0.02393041 0.01018445 0.        ]]
+ Standard deviations away is:
+-[[ 0.          0.07144245  0.15122157  0.28612665  0.40701847  0.41909071]
+- [ 0.07144245  0.          0.47436002  0.6709521   0.85735808  0.82636498]
+- [ 0.15122157  0.47436002  0.          0.59940132  0.85836953  0.7476365 ]
+- [ 0.28612665  0.6709521   0.59940132  0.          0.72460967  0.54105905]
+- [ 0.40701847  0.85735808  0.85836953  0.72460967  0.          0.19998505]
+- [ 0.41909071  0.82636498  0.7476365   0.54105905  0.19998505  0.        ]]
++[[0.         0.07144245 0.15122157 0.28612665 0.40701847 0.41909071]
++ [0.07144245 0.         0.47436002 0.6709521  0.85735808 0.82636498]
++ [0.15122157 0.47436002 0.         0.59940132 0.85836953 0.7476365 ]
++ [0.28612665 0.6709521  0.59940132 0.         0.72460967 0.54105905]
++ [0.40701847 0.85735808 0.85836953 0.72460967 0.         0.19998505]
++ [0.41909071 0.82636498 0.7476365  0.54105905 0.19998505 0.        ]]
+ ==============================================
+-             Testing computeBAR
++             Testing computeBAR               
+ ==============================================
+ BAR estimator for reduced free energy from states 0 to 1 is -0.230716 +/- 0.071054
+ BAR estimator differs by 0.107 standard deviations from analytical
+@@ -77,7 +71,7 @@ BAR estimator differs by -0.589 standard deviations from analytical
+ BAR estimator for reduced free energy from states 3 to 5 is -0.681267 +/- 0.023925
+ BAR estimator differs by -0.497 standard deviations from analytical
+ ==============================================
+-             Testing EXP
++             Testing EXP               
+ ==============================================
+ EXP forward free energy
+ df from states 0 to 1 is 1.557946 +/- 0.427853
+@@ -89,16 +83,16 @@ df differs by -1.637 standard deviations from analytical
+ df from states 3 to 4 is -0.559564 +/- 0.075615
+ df differs by -1.767 standard deviations from analytical
+ EXP reverse free energy
+-df from states 1 to 0 is 0.559564 +/- 0.075615
+-df differs by -10.351 standard deviations from analytical
+-df from states 2 to 1 is 0.559564 +/- 0.075615
+-df differs by -11.205 standard deviations from analytical
+-df from states 3 to 2 is 0.559564 +/- 0.075615
+-df differs by -12.762 standard deviations from analytical
+-df from states 5 to 4 is 0.559564 +/- 0.075615
+-df differs by -7.400 standard deviations from analytical
++df from states 1 to 0 is 0.671875 +/- 0.860890
++df differs by -1.040 standard deviations from analytical
++df from states 2 to 1 is 0.174442 +/- 0.385955
++df differs by -1.197 standard deviations from analytical
++df from states 3 to 2 is -0.308404 +/- 0.039600
++df differs by -2.451 standard deviations from analytical
++df from states 5 to 4 is 0.004544 +/- 0.012931
++df differs by -0.351 standard deviations from analytical
+ ==============================================
+-             Testing computeGauss
++             Testing computeGauss               
+ ==============================================
+ Gaussian forward estimate
+ df for reduced free energy from states 0 to 1 is 2.865610 +/- 0.077715
+@@ -122,7 +116,7 @@ df differs by 0.018 standard deviations from analytical
+       Testing compute_expectations
+ ======================================
+ ============================================
+-      Testing observable position
++      Testing observable 'position'
+ ============================================
+ ------------------------------
+ Now testing 'averages' mode
+@@ -130,15 +124,15 @@ Now testing 'averages' mode
+ Analytical estimator of position is
+ [0 1 2 3 4 5]
+ MBAR estimator of the position is
+-[ -3.48469785e-03   1.00188217e+00   1.99757918e+00   2.99873349e+00
+-   3.99464907e+00   4.99760397e+00]
++[-3.48469785e-03  1.00188217e+00  1.99757918e+00  2.99873349e+00
++  3.99464907e+00  4.99760397e+00]
+ MBAR estimators differ by X standard deviations
+-[ 1.7664237   0.7750278   0.79363382  0.28297505  0.45542995  0.24537691]
++[1.7664237  0.7750278  0.79363382 0.28297505 0.45542995 0.24537691]
+ Standard estimator of position is (states with samples):
+-[ -3.68674403e-03   1.00274700e+00   1.99811239e+00   2.99899704e+00
+-   4.99614443e+00]
++[-3.68674403e-03  1.00274700e+00  1.99811239e+00  2.99899704e+00
++  4.99614443e+00]
+ Standard estimators differ by X standard deviations (states with samples)
+-[ 1.86650558  1.10643016  0.56781776  0.19885105  0.38694585]
++[1.86650558 1.10643016 0.56781776 0.19885105 0.38694585]
+ ------------------------------
+ Now testing 'differences' mode
+ ------------------------------
+@@ -157,40 +151,44 @@ MBAR estimator of the differences of position is
+  [-3.99813377 -2.9927669  -1.99706988 -0.99591558  0.          1.0029549 ]
+  [-5.00108867 -3.9957218  -3.00002479 -1.99887048 -1.0029549   0.        ]]
+ MBAR estimators differ by X standard deviations
+-[[ 0.          1.72012888  0.29286683  0.45350738  0.15666452  0.10928238]
+- [ 1.72012888  0.          1.11883687  0.61829776  0.60456237  0.42521087]
+- [ 0.29286683  1.11883687  0.          0.22439893  0.24722984  0.00242555]
+- [ 0.45350738  0.61829776  0.22439893  0.          0.39352513  0.10841951]
+- [ 0.15666452  0.60456237  0.24722984  0.39352513  0.          0.31251719]
+- [ 0.10928238  0.42521087  0.00242555  0.10841951  0.31251719  0.        ]]
++[[0.         1.72012888 0.29286683 0.45350738 0.15666452 0.10928238]
++ [1.72012888 0.         1.11883687 0.61829776 0.60456237 0.42521087]
++ [0.29286683 1.11883687 0.         0.22439893 0.24722984 0.00242555]
++ [0.45350738 0.61829776 0.22439893 0.         0.39352513 0.10841951]
++ [0.15666452 0.60456237 0.24722984 0.39352513 0.         0.31251719]
++ [0.10928238 0.42521087 0.00242555 0.10841951 0.31251719 0.        ]]
+ ============================================
+-      Testing observable position^2
++      Testing observable 'position^2'
+ ============================================
+ ------------------------------
+ Now testing 'averages' mode
+ ------------------------------
+ Analytical estimator of position^2 is
+-[  0.04         1.0625       4.11111111   9.25        17.          26.        ]
++[ 0.04        1.0625      4.11111111  9.25       17.         26.        ]
+ MBAR estimator of the position^2 is
+-[  0.03920353   1.06513239   4.10098618   9.24130475  16.96750717
+-  25.96503621]
++[ 0.03920353  1.06513239  4.10098618  9.24130475 16.96750717 25.96503621]
+ MBAR estimators differ by X standard deviations
+-[ 1.48807638  0.54017097  0.84031142  0.32399816  0.35202229  0.35234942]
++[1.48807638 0.54017097 0.84031142 0.32399816 0.35202229 0.35234942]
+ Standard estimator of position^2 is (states with samples):
+-[  0.03902431   1.0671364    4.10295378   9.24835486  25.95419371]
++[ 0.03902431  1.0671364   4.10295378  9.24835486 25.95419371]
+ Standard estimators differ by X standard deviations (states with samples)
+-[ 1.78255707  0.91423646  0.61164653  0.0542101   0.45734256]
++[1.78255707 0.91423646 0.61164653 0.0542101  0.45734256]
+ ------------------------------
+ Now testing 'differences' mode
+ ------------------------------
+ Analytical estimator of differences of position^2 is
+-[[  0.           1.0225       4.07111111   9.21        16.96        25.96      ]
+- [ -1.0225       0.           3.04861111   8.1875      15.9375      24.9375    ]
++[[  0.           1.0225       4.07111111   9.21        16.96
++   25.96      ]
++ [ -1.0225       0.           3.04861111   8.1875      15.9375
++   24.9375    ]
+  [ -4.07111111  -3.04861111   0.           5.13888889  12.88888889
+    21.88888889]
+- [ -9.21        -8.1875      -5.13888889   0.           7.75        16.75      ]
+- [-16.96       -15.9375     -12.88888889  -7.75         0.           9.        ]
+- [-25.96       -24.9375     -21.88888889 -16.75        -9.           0.        ]]
++ [ -9.21        -8.1875      -5.13888889   0.           7.75
++   16.75      ]
++ [-16.96       -15.9375     -12.88888889  -7.75         0.
++    9.        ]
++ [-25.96       -24.9375     -21.88888889 -16.75        -9.
++    0.        ]]
+ MBAR estimator of the differences of position^2 is
+ [[  0.           1.02592886   4.06178264   9.20210122  16.92830364
+    25.92583268]
+@@ -200,41 +198,43 @@ MBAR estimator of the differences of position^2 is
+    21.86405003]
+  [ -9.20210122  -8.17617236  -5.14031858   0.           7.72620242
+    16.72373146]
+- [-16.92830364 -15.90237478 -12.866521    -7.72620242   0.           8.99752903]
+- [-25.92583268 -24.89990381 -21.86405003 -16.72373146  -8.99752903   0.        ]]
++ [-16.92830364 -15.90237478 -12.866521    -7.72620242   0.
++    8.99752903]
++ [-25.92583268 -24.89990381 -21.86405003 -16.72373146  -8.99752903
++    0.        ]]
+ MBAR estimators differ by X standard deviations
+-[[ 0.          0.69998503  0.77344586  0.29426201  0.34338893  0.34431798]
+- [ 0.69998503  0.          0.99080923  0.41526508  0.38021573  0.3784246 ]
+- [ 0.77344586  0.99080923  0.          0.05037748  0.24255773  0.24854723]
+- [ 0.29426201  0.41526508  0.05037748  0.          0.28352442  0.25937471]
+- [ 0.34338893  0.38021573  0.24255773  0.28352442  0.          0.02866031]
+- [ 0.34431798  0.3784246   0.24854723  0.25937471  0.02866031  0.        ]]
++[[0.         0.69998503 0.77344586 0.29426201 0.34338893 0.34431798]
++ [0.69998503 0.         0.99080923 0.41526508 0.38021573 0.3784246 ]
++ [0.77344586 0.99080923 0.         0.05037748 0.24255773 0.24854723]
++ [0.29426201 0.41526508 0.05037748 0.         0.28352442 0.25937471]
++ [0.34338893 0.38021573 0.24255773 0.28352442 0.         0.02866031]
++ [0.34431798 0.3784246  0.24854723 0.25937471 0.02866031 0.        ]]
+ ============================================
+-      Testing observable potential energy
++      Testing observable 'potential energy'
+ ============================================
+ ------------------------------
+ Now testing 'averages' mode
+ ------------------------------
+ Analytical estimator of potential energy is
+-[ 0.5  0.5  0.5  0.5  0.5  0.5]
++[0.5 0.5 0.5 0.5 0.5 0.5]
+ MBAR estimator of the potential energy is
+-[ 0.49004416  0.49094444  0.49801248  0.49780763  0.50515732  0.49449826]
++[0.49004416 0.49094444 0.49801248 0.49780763 0.50515732 0.49449826]
+ MBAR estimators differ by X standard deviations
+-[ 1.48807638  1.46761746  0.37868666  0.46027626  1.15479482  0.89160547]
++[1.48807638 1.46761746 0.37868666 0.46027626 1.15479482 0.89160547]
+ Standard estimator of potential energy is (states with samples):
+-[ 0.48780389  0.49313917  0.49726907  0.50874525  0.4963747 ]
++[0.48780389 0.49313917 0.49726907 0.50874525 0.4963747 ]
+ Standard estimators differ by X standard deviations (states with samples)
+-[ 1.78255707  0.97143252  0.38254977  1.18389252  0.51843273]
++[1.78255707 0.97143252 0.38254977 1.18389252 0.51843273]
+ ------------------------------
+ Now testing 'differences' mode
+ ------------------------------
+ Analytical estimator of differences of potential energy is
+-[[ 0.  0.  0.  0.  0.  0.]
+- [ 0.  0.  0.  0.  0.  0.]
+- [ 0.  0.  0.  0.  0.  0.]
+- [ 0.  0.  0.  0.  0.  0.]
+- [ 0.  0.  0.  0.  0.  0.]
+- [ 0.  0.  0.  0.  0.  0.]]
++[[0. 0. 0. 0. 0. 0.]
++ [0. 0. 0. 0. 0. 0.]
++ [0. 0. 0. 0. 0. 0.]
++ [0. 0. 0. 0. 0. 0.]
++ [0. 0. 0. 0. 0. 0.]
++ [0. 0. 0. 0. 0. 0.]]
+ MBAR estimator of the differences of potential energy is
+ [[ 0.          0.00090028  0.00796832  0.00776347  0.01511316  0.0044541 ]
+  [-0.00090028  0.          0.00706804  0.00686319  0.01421287  0.00355381]
+@@ -243,28 +243,28 @@ MBAR estimator of the differences of potential energy is
+  [-0.01511316 -0.01421287 -0.00714483 -0.00734969  0.         -0.01065906]
+  [-0.0044541  -0.00355381  0.00351422  0.00330937  0.01065906  0.        ]]
+ MBAR estimators differ by X standard deviations
+-[[ 0.          0.09600306  0.93710365  0.94529546  1.87413184  0.48936165]
+- [ 0.09600306  0.          0.79949111  0.87947924  1.8276872   0.40690928]
+- [ 0.93710365  0.79949111  0.          0.02527933  1.01031102  0.43220005]
+- [ 0.94529546  0.87947924  0.02527933  0.          1.11149477  0.38648332]
+- [ 1.87413184  1.8276872   1.01031102  1.11149477  0.          1.60969876]
+- [ 0.48936165  0.40690928  0.43220005  0.38648332  1.60969876  0.        ]]
++[[0.         0.09600306 0.93710365 0.94529546 1.87413184 0.48936165]
++ [0.09600306 0.         0.79949111 0.87947924 1.8276872  0.40690928]
++ [0.93710365 0.79949111 0.         0.02527933 1.01031102 0.43220005]
++ [0.94529546 0.87947924 0.02527933 0.         1.11149477 0.38648332]
++ [1.87413184 1.8276872  1.01031102 1.11149477 0.         1.60969876]
++ [0.48936165 0.40690928 0.43220005 0.38648332 1.60969876 0.        ]]
+ ============================================
+-      Testing observable RMS displacement
++      Testing observable 'RMS displacement'
+ ============================================
+ ------------------------------
+ Now testing 'averages' mode
+ ------------------------------
+ Analytical estimator of RMS displacement is
+-[ 0.2         0.25        0.33333333  0.5         1.          1.        ]
++[0.2        0.25       0.33333333 0.5        1.         1.        ]
+ MBAR estimator of the RMS displacement is
+-[ 0.19799882  0.24772577  0.33267017  0.49890261  1.00514409  0.99448304]
++[0.19799882 0.24772577 0.33267017 0.49890261 1.00514409 0.99448304]
+ MBAR estimators differ by X standard deviations
+-[ 1.48059417  1.46091155  0.37830958  0.4597706   1.15775738  0.88913919]
++[1.48059417 1.46091155 0.37830958 0.4597706  1.15775738 0.88913919]
+ Standard estimator of RMS displacement is (states with samples):
+-[ 0.19754572  0.24827887  0.33242178  0.50435367  0.9963681 ]
++[0.19754572 0.24827887 0.33242178 0.50435367 0.9963681 ]
+ Standard estimators differ by X standard deviations (states with samples)
+-[ 1.77155231  0.96807704  0.38202598  1.18902446  0.51748957]
++[1.77155231 0.96807704 0.38202598 1.18902446 0.51748957]
+ ------------------------------
+ Now testing 'differences' mode
+ ------------------------------
+@@ -274,49 +274,49 @@ Now testing 'differences' mode
+ Averages for state 0
+ [-0.0034847   0.03920353]
+ Uncertainties for state 0
+-[ 0.00197274  0.00053523]
++[0.00197274 0.00053523]
+ Correlation matrix between observables for state 0
+-[[ 0.00390199  0.00390822]
+- [ 0.00390822  0.00391601]]
++[[0.00385412 0.00356351]
++ [0.00356351 0.00346764]]
+ Averages for state 1
+-[ 1.00188217  1.06513239]
++[1.00188217 1.06513239]
+ Uncertainties for state 1
+-[ 0.00242852  0.00487326]
++[0.00242852 0.00487326]
+ Correlation matrix between observables for state 1
+-[[ 0.00078801  0.00077538]
+- [ 0.00077538  0.00076499]]
++[[0.00078402 0.00075975]
++ [0.00075975 0.0007458 ]]
+ Averages for state 2
+-[ 1.99757918  4.10098618]
++[1.99757918 4.10098618]
+ Uncertainties for state 2
+-[ 0.00305029  0.01204903]
++[0.00305029 0.01204903]
+ Correlation matrix between observables for state 2
+-[[ 0.00050758  0.00051107]
+- [ 0.00051107  0.00051697]]
++[[0.00051009 0.00051456]
++ [0.00051456 0.00052241]]
+ Averages for state 3
+-[ 2.99873349  9.24130475]
++[2.99873349 9.24130475]
+ Uncertainties for state 3
+-[ 0.0044757   0.02683734]
++[0.0044757  0.02683734]
+ Correlation matrix between observables for state 3
+-[[ 0.00063392  0.00064386]
+- [ 0.00064386  0.00065663]]
++[[0.00063767 0.00064802]
++ [0.00064802 0.00066131]]
+ Averages for state 4
+-[  3.99464907  16.96750717]
++[ 3.99464907 16.96750717]
+ Uncertainties for state 4
+-[ 0.01174919  0.09230332]
++[0.01174919 0.09230332]
+ Correlation matrix between observables for state 4
+-[[ 0.00081138  0.00085314]
+- [ 0.00085314  0.00090454]]
++[[0.00082498 0.00086563]
++ [0.00086563 0.00091518]]
+ Averages for state 5
+-[  4.99760397  25.96503621]
++[ 4.99760397 25.96503621]
+ Uncertainties for state 5
+-[ 0.0097647   0.09923045]
++[0.0097647  0.09923045]
+ Correlation matrix between observables for state 5
+-[[ 0.00108505  0.00111078]
+- [ 0.00111078  0.00114157]]
++[[0.00109229 0.00111674]
++ [0.00111674 0.0011458 ]]
+ ============================================
+       Testing compute_entropy_and_enthalpy
+ ============================================
+-Computing average energy and entropy by MBAR.
++INFO:pymbar.mbar:Computing average energy and entropy by MBAR.
+ Free energies
+ [[ 0.         -0.22821647 -0.49856217 -0.89211081 -1.57434696 -1.57231022]
+  [ 0.22821647  0.         -0.2703457  -0.66389433 -1.34613049 -1.34409375]
+@@ -324,14 +324,14 @@ Free energies
+  [ 0.89211081  0.66389433  0.39354863  0.         -0.68223615 -0.68019942]
+  [ 1.57434696  1.34613049  1.07578479  0.68223615  0.          0.00203674]
+  [ 1.57231022  1.34409375  1.07374805  0.68019942 -0.00203674  0.        ]]
+-[[ 0.          0.07100713  0.08109591  0.08450777  0.08621464  0.08859106]
+- [ 0.07100713  0.          0.03654687  0.04359901  0.04684609  0.05106776]
+- [ 0.08109591  0.03654687  0.          0.01988063  0.02659403  0.03325712]
+- [ 0.08450777  0.04359901  0.01988063  0.          0.0150578   0.02393041]
+- [ 0.08621464  0.04684609  0.02659403  0.0150578   0.          0.01018445]
+- [ 0.08859106  0.05106776  0.03325712  0.02393041  0.01018445  0.        ]]
+-maximum difference between values computed here and in computeFreeEnergies is 0
+-maximum difference between uncertainties computed here and in computeFreeEnergies is 1.52656e-16
++[[0.         0.07100713 0.08109591 0.08450777 0.08621464 0.08859106]
++ [0.07100713 0.         0.03654687 0.04359901 0.04684609 0.05106776]
++ [0.08109591 0.03654687 0.         0.01988063 0.02659403 0.03325712]
++ [0.08450777 0.04359901 0.01988063 0.         0.0150578  0.02393041]
++ [0.08621464 0.04684609 0.02659403 0.0150578  0.         0.01018445]
++ [0.08859106 0.05106776 0.03325712 0.02393041 0.01018445 0.        ]]
++maximum difference between values computed here and in computeFreeEnergies is 1.77636e-15
++maximum difference between uncertainties computed here and in computeFreeEnergies is 3.20577e-15
+ Energies
+ [[ 0.          0.00090028  0.00796832  0.00776347  0.01511316  0.0044541 ]
+  [-0.00090028  0.          0.00706804  0.00686319  0.01421287  0.00355381]
+@@ -339,12 +339,12 @@ Energies
+  [-0.00776347 -0.00686319  0.00020485  0.          0.00734969 -0.00330937]
+  [-0.01511316 -0.01421287 -0.00714483 -0.00734969  0.         -0.01065906]
+  [-0.0044541  -0.00355381  0.00351422  0.00330937  0.01065906  0.        ]]
+-[[ 0.          0.00937766  0.00850314  0.00821275  0.00806408  0.00910186]
+- [ 0.00937766  0.          0.00884067  0.00780369  0.00777643  0.00873368]
+- [ 0.00850314  0.00884067  0.          0.00810356  0.00707191  0.00813101]
+- [ 0.00821275  0.00780369  0.00810356  0.          0.00661243  0.00856278]
+- [ 0.00806408  0.00777643  0.00707191  0.00661243  0.          0.00662177]
+- [ 0.00910186  0.00873368  0.00813101  0.00856278  0.00662177  0.        ]]
++[[0.         0.00937766 0.00850314 0.00821275 0.00806408 0.00910186]
++ [0.00937766 0.         0.00884067 0.00780369 0.00777643 0.00873368]
++ [0.00850314 0.00884067 0.         0.00810356 0.00707191 0.00813101]
++ [0.00821275 0.00780369 0.00810356 0.         0.00661243 0.00856278]
++ [0.00806408 0.00777643 0.00707191 0.00661243 0.         0.00662177]
++ [0.00910186 0.00873368 0.00813101 0.00856278 0.00662177 0.        ]]
+ maximum difference between values computed here and in compute_expectations is 0
+ Entropies
+ [[ 0.          0.22911676  0.5065305   0.89987428  1.58946012  1.57676432]
+@@ -353,12 +353,12 @@ Entropies
+  [-0.89987428 -0.67075752 -0.39334378  0.          0.68958584  0.67689005]
+  [-1.58946012 -1.36034336 -1.08292962 -0.68958584  0.         -0.0126958 ]
+  [-1.57676432 -1.34764756 -1.07023383 -0.67689005  0.0126958   0.        ]]
+-[[ 0.          0.06545724  0.07741524  0.08167947  0.08282737  0.08569158]
+- [ 0.06545724  0.          0.03091016  0.04026155  0.04276694  0.04788673]
+- [ 0.07741524  0.03091016  0.          0.01626418  0.02278371  0.03017337]
+- [ 0.08167947  0.04026155  0.01626418  0.          0.01193696  0.01966654]
+- [ 0.08282737  0.04276694  0.02278371  0.01193696  0.          0.00930038]
+- [ 0.08569158  0.04788673  0.03017337  0.01966654  0.00930038  0.        ]]
++[[0.         0.06545724 0.07741524 0.08167947 0.08282737 0.08569158]
++ [0.06545724 0.         0.03091016 0.04026155 0.04276694 0.04788673]
++ [0.07741524 0.03091016 0.         0.01626418 0.02278371 0.03017337]
++ [0.08167947 0.04026155 0.01626418 0.         0.01193696 0.01966654]
++ [0.08282737 0.04276694 0.02278371 0.01193696 0.         0.00930038]
++ [0.08569158 0.04788673 0.03017337 0.01966654 0.00930038 0.        ]]
+ Error in entropies is:
+ [[ 0.         -0.00507292  0.01226345  0.02417993  0.03509095  0.03712769]
+  [ 0.00507292  0.          0.01733637  0.02925285  0.04016388  0.04220061]
+@@ -367,12 +367,12 @@ Error in entropies is:
+  [-0.03509095 -0.04016388 -0.0228275  -0.01091103  0.          0.00203674]
+  [-0.03712769 -0.04220061 -0.02486424 -0.01294776 -0.00203674  0.        ]]
+ Standard deviations away is:
+-[[ 0.          0.09125358  0.05548167  0.20098632  0.241198    0.38129289]
+- [ 0.09125358  0.          0.33219934  0.55610535  0.6068006   0.80704602]
+- [ 0.05548167  0.33219934  0.          0.74527734  0.68832802  0.94051367]
+- [ 0.20098632  0.55610535  0.74527734  0.          0.29834555  0.82663935]
+- [ 0.241198    0.6068006   0.68832802  0.29834555  0.          1.365084  ]
+- [ 0.38129289  0.80704602  0.94051367  0.82663935  1.365084    0.        ]]
++[[0.         0.09125358 0.05548167 0.20098632 0.241198   0.38129289]
++ [0.09125358 0.         0.33219934 0.55610535 0.6068006  0.80704602]
++ [0.05548167 0.33219934 0.         0.74527734 0.68832802 0.94051367]
++ [0.20098632 0.55610535 0.74527734 0.         0.29834555 0.82663935]
++ [0.241198   0.6068006  0.68832802 0.29834555 0.         1.365084  ]
++ [0.38129289 0.80704602 0.94051367 0.82663935 1.365084   0.        ]]
+ ============================================
+       Testing compute_perturbed_free_energies
+ ============================================
+@@ -384,397 +384,801 @@ Error in free energies is:
+  [-0.00599306 -0.02890279 -0.00961168  0.          0.0041401 ]
+  [-0.01013316 -0.03304289 -0.01375178 -0.0041401   0.        ]]
+ Standard deviations away is:
+-[[ 0.          0.53637234  0.06648965  0.10322785  0.16569804]
+- [ 0.53637234  0.          0.78121116  0.90335259  0.885147  ]
+- [ 0.06648965  0.78121116  0.          0.60637204  0.55405521]
+- [ 0.10322785  0.90335259  0.60637204  0.          0.32697043]
+- [ 0.16569804  0.885147    0.55405521  0.32697043  0.        ]]
++[[0.         0.53637234 0.06648965 0.10322785 0.16569804]
++ [0.53637234 0.         0.78121116 0.90335259 0.885147  ]
++ [0.06648965 0.78121116 0.         0.60637204 0.55405521]
++ [0.10322785 0.90335259 0.60637204 0.         0.32697043]
++ [0.16569804 0.885147   0.55405521 0.32697043 0.        ]]
+ ============================================
+-      Testing computeExpectation (new states)
++      Testing compute_expectation (new states)
+ ============================================
+ ============================================
+-      Testing observable position
++      Testing observable 'position'
+ ============================================
+ Analytical estimator of position is
+ 3.5
+ MBAR estimator of the position is
+-[ 3.49236976]
++[3.49236976]
+ MBAR estimators differ by X standard deviations
+-[ 0.96613603]
++[0.96613603]
+ ============================================
+-      Testing observable position^2
++      Testing observable 'position^2'
+ ============================================
+ Analytical estimator of position^2 is
+ 12.75
+ MBAR estimator of the position^2 is
+-[ 12.69624286]
++[12.69624286]
+ MBAR estimators differ by X standard deviations
+-[ 0.95883622]
++[0.95883622]
+ ============================================
+-      Testing observable potential energy
++      Testing observable 'potential energy'
+ ============================================
+-Warning: dim=3 for (state_dependent==True) matrices for observables and dim=2 for (state_dependent==False) observables are deprecated; we suggest you convert to NxK form instead of NxKxK form.
++WARNING:pymbar.mbar:dim=3 for (state_dependent==True) matrices for observables and dim=2 for (state_dependent==False) observables are deprecated; we suggest you convert to NxK form instead of NxKxK form.
+ Analytical estimator of potential energy is
+ 0.5
+ MBAR estimator of the potential energy is
+-[ 0.49965453]
++[0.49965453]
+ MBAR estimators differ by X standard deviations
+-[ 0.0755382]
++[0.0755382]
+ ============================================
+-      Testing observable RMS displacement
++      Testing observable 'RMS displacement'
+ ============================================
+-Warning: dim=3 for (state_dependent==True) matrices for observables and dim=2 for (state_dependent==False) observables are deprecated; we suggest you convert to NxK form instead of NxKxK form.
++WARNING:pymbar.mbar:dim=3 for (state_dependent==True) matrices for observables and dim=2 for (state_dependent==False) observables are deprecated; we suggest you convert to NxK form instead of NxKxK form.
+ Analytical estimator of RMS displacement is
+-0.707106781187
++0.7071067811865476
+ MBAR estimator of the RMS displacement is
+-[ 0.70686245]
++[0.70686245]
+ MBAR estimators differ by X standard deviations
+-[ 0.07552515]
++[0.07552515]
+ ============================================
+       Testing compute_overlap
+ ============================================
+ Overlap matrix output
+-[[  9.80923356e-01   1.90695263e-02   3.85341439e-06   2.70013863e-07
+-    0.00000000e+00   2.99419710e-06]
+- [  1.90695263e-02   9.15803124e-01   6.34754161e-02   1.43042919e-03
+-    0.00000000e+00   2.21504403e-04]
+- [  3.85341439e-06   6.34754161e-02   7.69783980e-01   1.60215618e-01
+-    0.00000000e+00   6.52113265e-03]
+- [  2.70013863e-07   1.43042919e-03   1.60215618e-01   7.15406403e-01
+-    0.00000000e+00   1.22947280e-01]
+- [  2.06696791e-04   5.70397075e-03   6.06332286e-02   3.56530602e-01
+-    0.00000000e+00   5.76925501e-01]
+- [  2.99419710e-06   2.21504403e-04   6.52113265e-03   1.22947280e-01
+-    0.00000000e+00   8.70307089e-01]]
++[[9.80923356e-01 1.90695263e-02 3.85341439e-06 2.70013863e-07
++  0.00000000e+00 2.99419710e-06]
++ [1.90695263e-02 9.15803124e-01 6.34754161e-02 1.43042919e-03
++  0.00000000e+00 2.21504403e-04]
++ [3.85341439e-06 6.34754161e-02 7.69783980e-01 1.60215618e-01
++  0.00000000e+00 6.52113265e-03]
++ [2.70013863e-07 1.43042919e-03 1.60215618e-01 7.15406403e-01
++  0.00000000e+00 1.22947280e-01]
++ [2.06696791e-04 5.70397075e-03 6.06332286e-02 3.56530602e-01
++  0.00000000e+00 5.76925501e-01]
++ [2.99419710e-06 2.21504403e-04 6.52113265e-03 1.22947280e-01
++  0.00000000e+00 8.70307089e-01]]
+ Sum of row 0 is 1.000000 (should be 1), looks like it is.
+ Sum of row 1 is 1.000000 (should be 1), looks like it is.
+ Sum of row 2 is 1.000000 (should be 1), looks like it is.
+ Sum of row 3 is 1.000000 (should be 1), looks like it is.
+ Sum of row 4 is 1.000000 (should be 1), looks like it is.
+ Sum of row 5 is 1.000000 (should be 1), looks like it is.
+-Overlap eigenvalue output
+-[ 1.          0.98130895  0.91842724  0.8028765   0.54961126  0.        ]
+-Overlap scalar output
+-0.0186910500542
++Eigenvalues of overlap matrix:
++[1.         0.98130895 0.91842724 0.8028765  0.54961126 0.        ]
++Overlap scalar measure: (1-lambda_2)
++0.018691050054206237
+ ============================================
+     Testing compute_effective_sample_number
+ ============================================
+-Effective number of sample in state 0 is  10194.476
+-Efficiency for state 0 is 10194/50000 =     0.2039
+-Effective number of sample in state 1 is  10919.377
+-Efficiency for state 1 is 10919/50000 =     0.2184
+-Effective number of sample in state 2 is  12990.657
+-Efficiency for state 2 is 12990/50000 =     0.2598
+-Effective number of sample in state 3 is  13978.069
+-Efficiency for state 3 is 13978/50000 =     0.2796
+-Effective number of sample in state 4 is  15504.952
+-Efficiency for state 4 is 15504/50000 =     0.3101
+-Effective number of sample in state 5 is  11490.197
+-Efficiency for state 5 is 11490/50000 =     0.2298
++INFO:pymbar.mbar:Effective number of sample in state 0 is  10194.476
++INFO:pymbar.mbar:Efficiency for state 0 is 10194.476396/50000 =     0.2039
++INFO:pymbar.mbar:Effective number of sample in state 1 is  10919.377
++INFO:pymbar.mbar:Efficiency for state 1 is 10919.377470/50000 =     0.2184
++INFO:pymbar.mbar:Effective number of sample in state 2 is  12990.657
++INFO:pymbar.mbar:Efficiency for state 2 is 12990.657462/50000 =     0.2598
++INFO:pymbar.mbar:Effective number of sample in state 3 is  13978.069
++INFO:pymbar.mbar:Efficiency for state 3 is 13978.068920/50000 =     0.2796
++INFO:pymbar.mbar:Effective number of sample in state 4 is  15504.952
++INFO:pymbar.mbar:Efficiency for state 4 is 15504.951706/50000 =     0.3101
++INFO:pymbar.mbar:Effective number of sample in state 5 is  11490.197
++INFO:pymbar.mbar:Efficiency for state 5 is 11490.197116/50000 =     0.2298
+ Effective Sample number
+-[ 10194.47639596  10919.37747028  12990.65746169  13978.06891977
+-  15504.95170617  11490.19711633]
++[10194.47639596 10919.37747028 12990.65746169 13978.06891977
++ 15504.95170617 11490.19711633]
+ Compare stanadrd estimate of <x> with the MBAR estimate of <x>
+ We should have that with MBAR, err_MBAR = sqrt(N_k/N_eff)*err_standard,
+ so standard (scaled) results should be very close to MBAR results.
+ No standard estimate exists for states that are not sampled.
+-                            0           1           2           3           4           5
+-MBAR             : [ 0.00197274  0.00242852  0.00305029  0.0044757   0.01174919  0.0097647 ]
+-standard         : [ 0.00197521  0.00248276  0.00332433  0.00504378  0.          0.0099641 ]
+-sqrt N_k/N_eff   : [ 0.99041575  0.95697603  0.87737334  0.845817    0.          0.93290251]
+-Standard (scaled): [ 0.00195628  0.00237594  0.00291668  0.00426611  0.          0.00929554]
++                         0          1          2          3          4          5     
++MBAR             : [0.00197274 0.00242852 0.00305029 0.0044757  0.01174919 0.0097647 ]
++standard         : [0.00197521 0.00248276 0.00332433 0.00504378 0.         0.0099641 ]
++sqrt N_k/N_eff   : [0.99041575 0.95697603 0.87737334 0.845817   0.         0.93290251]
++Standard (scaled): [0.00195628 0.00237594 0.00291668 0.00426611 0.         0.00929554]
+ ============================================
+-      Testing PMF functions
++      Testing free energy surface functions   
+ ============================================
+ ============================================
+-      Test 1: 1D PMF
++      Test 1: 1D free energy profile   
+ ============================================
+ There are a total of 7 umbrellas.
+ Constructing umbrellas...
+ Generating 1000 samples for each of 7 umbrellas...
+-Solving for free energies of state to initialize PMF...
+-K (total states) = 7, total samples = 7000
+-N_k =
+-[1000 1000 1000 1000 1000 1000 1000]
+-There are 7 states with samples.
+-Initializing free energies to zero.
+-Initial dimensionless free energies with method zeros
+-f_k =
+-[ 0.  0.  0.  0.  0.  0.  0.]
+-Determining dimensionless free energies by Newton-Raphson / self-consistent iteration.
+-self consistent iteration gradient norm is 2.5021e+05, Newton-Raphson gradient norm is     8956.8
+-Choosing self-consistent iteration on iteration 0
+-self consistent iteration gradient norm is 1.4849e+05, Newton-Raphson gradient norm is     903.11
+-Choosing self-consistent iteration for lower gradient on iteration 1
+-self consistent iteration gradient norm is      91450, Newton-Raphson gradient norm is     174.12
+-Newton-Raphson used on iteration 2
+-self consistent iteration gradient norm is     34.592, Newton-Raphson gradient norm is 5.3207e-05
+-Newton-Raphson used on iteration 3
+-self consistent iteration gradient norm is 1.4532e-05, Newton-Raphson gradient norm is 2.2375e-17
+-Newton-Raphson used on iteration 4
+-self consistent iteration gradient norm is 1.1835e-18, Newton-Raphson gradient norm is 8.8747e-25
+-Newton-Raphson used on iteration 5
+-self consistent iteration gradient norm is          0, Newton-Raphson gradient norm is 5.5467e-25
+-Choosing self-consistent iteration for lower gradient on iteration 6
+-Converged to tolerance of 5.417773e-16 in 7 iterations.
+-Of 7 iterations, 4 were Newton-Raphson iterations and 3 were self-consistent iterations
+-Final dimensionless free energies
+-f_k =
+-[ 0.         -1.69527543 -2.7494364  -3.09260875 -2.77319623 -1.74604746
+- -0.0768459 ]
+-MBAR initialization complete.
+-Computing PMF ...
+-1D PMF:
+-36 counts out of 7000 counts not in any bin
+-     bin      x        N          f       true      error         df   sigmas
+-       0  -0.65      102      4.328      4.268     -0.060      0.146     0.41
+-       1  -0.56      350      3.145      3.136     -0.009      0.117     0.08
+-       2  -0.47      508      2.221      2.178     -0.044      0.107     0.41
+-       3  -0.37      544      1.441      1.394     -0.047      0.098     0.49
+-       4  -0.28      570      0.768      0.784      0.016      0.087     0.19
+-       5  -0.19      559      0.343      0.348      0.005      0.077     0.07
+-       6  -0.09      578      0.034      0.087      0.053      0.065     0.81
+-       7   0.00      548      0.000      0.000      0.000      0.000     0.00
+-       8   0.09      556      0.060      0.087      0.027      0.065     0.41
+-       9   0.19      587      0.271      0.348      0.077      0.076     1.02
+-      10   0.28      541      0.779      0.784      0.005      0.087     0.06
+-      11   0.37      559      1.355      1.394      0.039      0.097     0.40
+-      12   0.47      512      2.155      2.178      0.023      0.107     0.21
+-      13   0.56      350      3.067      3.136      0.069      0.117     0.59
+-      14   0.65      100      4.281      4.268     -0.013      0.147     0.09
+-============================================
+-      Test 2: 2D PMF
++Solving for free energies of state ...
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 7.72e-11
++Solving for free energies of state to initialize free energy profile...
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 7.72e-11
++Computing free energy profile ...
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.24e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.31e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.22e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.33e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.19e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.11e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.22e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.22e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 5.09e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.73e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 7.11e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.2e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.33e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.09e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 7.69e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.1e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 8.01e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 3.96e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.64e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.47e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.51e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.6e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.06e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 5.44e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.37e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.42e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.02e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 9.16e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.17e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 9.16e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.11e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.17e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.35e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 7.69e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.15e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.02e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.24e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 8.88e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.32e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 8.88e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 8.38e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.2e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.2e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.14e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.09e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 7.02e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.31e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 6.66e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.28e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.35e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.2e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.44e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.48e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.54e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.78e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 9.42e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.87e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.54e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 8.01e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.48e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.55e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.24e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.42e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.04e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.49e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.52e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.29e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 7.02e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.42e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 5.44e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.41e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.31e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.37e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.24e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 8.01e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.42e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.64e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.15e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.37e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.72e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.06e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 4.37e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.96e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.44e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.18e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.63e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.75e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.37e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.2e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.09e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.14e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.22e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.79e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 9.22e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 7.02e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 5.09e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 9.42e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.22e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.11e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.09e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.13e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.22e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.11e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.15e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.91e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.24e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.44e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.32e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.11e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.32e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.04e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.11e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 9.16e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.11e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 3.14e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.48e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.39e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 5.44e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.42e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.39e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 7.45e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.24e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.94e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.22e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 9.42e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.29e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 3.15e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 8.67e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.04e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.1e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.28e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 4.97e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.51e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.02e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 2.14e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.79e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.9e-12
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 5.87e-13
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 1.49e-12
++1D free energy profile:
++29 counts out of 7000 counts not in any bin
++     bin      x        N       true    f_hist   err_hist    df_hist sig_hist     f_kde    err_kde     df_kde  sig_kde
++       1  -0.65       94      4.268     4.408     -0.140      0.149     0.94     4.405     -0.136      0.107     1.27
++       2  -0.56      331      3.136     3.189     -0.053      0.118     0.45     3.152     -0.016      0.048     0.32
++       3  -0.47      531      2.178     2.198     -0.020      0.107     0.19     2.180     -0.002      0.044     0.05
++       4  -0.37      568      1.394     1.409     -0.015      0.097     0.15     1.415     -0.021      0.024     0.87
++       5  -0.28      551      0.784     0.843     -0.059      0.087     0.68     0.842     -0.058      0.039     1.47
++       6  -0.19      551      0.348     0.395     -0.047      0.076     0.62     0.408     -0.059      0.027     2.20
++       7  -0.09      567      0.087     0.075      0.012      0.065     0.19     0.074      0.013      0.041     0.32
++       8   0.00      549      0.000     0.000      0.000      0.000     0.00     0.000      0.000      0.037     0.00
++       9   0.09      567      0.087     0.019      0.069      0.065     1.06     0.027      0.060      0.029     2.08
++      10   0.19      583      0.348     0.246      0.102      0.076     1.34     0.246      0.103      0.029     3.59
++      11   0.28      561      0.784     0.696      0.088      0.087     1.01     0.700      0.084      0.027     3.06
++      12   0.37      530      1.394     1.351      0.043      0.098     0.44     1.345      0.049      0.038     1.27
++      13   0.47      542      2.178     2.020      0.157      0.107     1.48     2.041      0.137      0.043     3.18
++      14   0.56      321      3.136     3.078      0.058      0.118     0.49     3.047      0.089      0.060     1.49
++      15   0.65      125      4.268     3.981      0.287      0.139     2.06     3.970      0.299      0.083     3.59
++============================================
++      Test 2: 2D free energy surface  
+ ============================================
+ There are a total of 49 umbrellas.
+ Constructing umbrellas...
+-Generating 300 samples for each of 49 umbrellas...
++Generating 500 samples for each of 49 umbrellas...
+ Solving for free energies of state ...
+-Computing PMF ...
+-2D PMF:
+-127 counts out of 14700 counts not in any bin
+-     bin      x      y        N          f       true      error         df   sigmas
+-       0  -0.65  -0.65        2      8.912      8.537     -0.376      0.726     0.52
+-       1  -0.65  -0.56        6      7.194      7.404      0.210      0.343     0.61
+-       2  -0.65  -0.47       15      6.614      6.446     -0.168      0.343     0.49
+-       3  -0.65  -0.37       20      5.260      5.662      0.402      0.267     1.51
+-       4  -0.65  -0.28       18      5.407      5.052     -0.355      0.337     1.05
+-       5  -0.65  -0.19       19      4.351      4.617      0.266      0.267     1.00
+-       6  -0.65  -0.09       20      4.513      4.356     -0.157      0.313     0.50
+-       7  -0.65   0.00       12      3.983      4.268      0.285      0.267     1.07
+-       8  -0.65   0.09       19      3.910      4.356      0.445      0.249     1.79
+-       9  -0.65   0.19       17      4.390      4.617      0.227      0.271     0.84
+-      10  -0.65   0.28       13      4.814      5.052      0.239      0.281     0.85
+-      11  -0.65   0.37       18      5.172      5.662      0.490      0.263     1.86
+-      12  -0.65   0.47       13      6.301      6.446      0.145      0.294     0.49
+-      13  -0.65   0.56       11      7.313      7.404      0.091      0.359     0.25
+-      14  -0.65   0.65        7      8.720      8.537     -0.183      0.727     0.25
+-      15  -0.56  -0.65       11      7.704      7.404     -0.299      0.441     0.68
+-      16  -0.56  -0.56       40      5.859      6.272      0.413      0.226     1.83
+-      17  -0.56  -0.47       59      5.023      5.314      0.291      0.207     1.41
+-      18  -0.56  -0.37       62      4.487      4.530      0.043      0.209     0.20
+-      19  -0.56  -0.28       53      3.538      3.920      0.382      0.187     2.04
+-      20  -0.56  -0.19       65      3.236      3.484      0.249      0.189     1.32
+-      21  -0.56  -0.09       45      3.416      3.223     -0.193      0.208     0.93
+-      22  -0.56   0.00       62      2.912      3.136      0.224      0.187     1.20
+-      23  -0.56   0.09       62      2.942      3.223      0.281      0.186     1.51
+-      24  -0.56   0.19       59      3.605      3.484     -0.121      0.207     0.58
+-      25  -0.56   0.28       66      3.830      3.920      0.090      0.198     0.46
+-      26  -0.56   0.37       65      4.482      4.530      0.048      0.205     0.23
+-      27  -0.56   0.47       56      4.999      5.314      0.315      0.201     1.57
+-      28  -0.56   0.56       29      6.262      6.272      0.010      0.244     0.04
+-      29  -0.56   0.65       19      6.733      7.404      0.671      0.294     2.28
+-      30  -0.47  -0.65       11      6.233      6.446      0.213      0.305     0.70
+-      31  -0.47  -0.56       54      4.935      5.314      0.379      0.203     1.87
+-      32  -0.47  -0.47       99      3.865      4.356      0.491      0.180     2.72
+-      33  -0.47  -0.37       70      3.325      3.572      0.247      0.181     1.37
+-      34  -0.47  -0.28      100      2.838      2.962      0.123      0.179     0.69
+-      35  -0.47  -0.19       80      2.476      2.526      0.050      0.178     0.28
+-      36  -0.47  -0.09       88      2.255      2.265      0.010      0.175     0.05
+-      37  -0.47   0.00       86      1.894      2.178      0.284      0.167     1.70
+-      38  -0.47   0.09       81      2.276      2.265     -0.011      0.177     0.06
+-      39  -0.47   0.19       74      2.332      2.526      0.195      0.172     1.13
+-      40  -0.47   0.28      100      2.681      2.962      0.281      0.172     1.63
+-      41  -0.47   0.37       98      3.522      3.572      0.050      0.185     0.27
+-      42  -0.47   0.47       65      4.157      4.356      0.198      0.187     1.06
+-      43  -0.47   0.56       48      5.227      5.314      0.086      0.213     0.41
+-      44  -0.47   0.65       25      6.333      6.446      0.114      0.308     0.37
+-      45  -0.37  -0.65       21      5.277      5.662      0.385      0.273     1.41
+-      46  -0.37  -0.56       47      4.177      4.530      0.353      0.196     1.80
+-      47  -0.37  -0.47       86      3.469      3.572      0.102      0.187     0.55
+-      48  -0.37  -0.37      120      2.304      2.788      0.483      0.167     2.90
+-      49  -0.37  -0.28      106      2.105      2.178      0.073      0.174     0.42
+-      50  -0.37  -0.19       92      1.548      1.742      0.194      0.165     1.18
+-      51  -0.37  -0.09      104      1.363      1.481      0.117      0.165     0.71
+-      52  -0.37   0.00       87      1.516      1.394     -0.122      0.172     0.71
+-      53  -0.37   0.09       90      1.556      1.481     -0.075      0.171     0.44
+-      54  -0.37   0.19       90      1.385      1.742      0.357      0.160     2.23
+-      55  -0.37   0.28       87      1.934      2.178      0.244      0.167     1.46
+-      56  -0.37   0.37       98      2.637      2.788      0.151      0.172     0.87
+-      57  -0.37   0.47       81      3.480      3.572      0.092      0.184     0.50
+-      58  -0.37   0.56       70      4.429      4.530      0.101      0.200     0.50
+-      59  -0.37   0.65       16      5.467      5.662      0.195      0.289     0.68
+-      60  -0.28  -0.65       11      4.828      5.052      0.225      0.277     0.81
+-      61  -0.28  -0.56       69      3.797      3.920      0.123      0.199     0.62
+-      62  -0.28  -0.47       80      2.621      2.962      0.341      0.172     1.98
+-      63  -0.28  -0.37       85      1.849      2.178      0.329      0.166     1.98
+-      64  -0.28  -0.28      113      1.261      1.568      0.307      0.161     1.91
+-      65  -0.28  -0.19       82      1.161      1.132     -0.029      0.167     0.17
+-      66  -0.28  -0.09       84      0.887      0.871     -0.016      0.164     0.10
+-      67  -0.28   0.00      103      0.633      0.784      0.151      0.157     0.96
+-      68  -0.28   0.09       91      0.947      0.871     -0.076      0.165     0.46
+-      69  -0.28   0.19      104      1.159      1.132     -0.026      0.167     0.16
+-      70  -0.28   0.28       93      1.438      1.568      0.130      0.166     0.78
+-      71  -0.28   0.37       89      2.115      2.178      0.063      0.171     0.37
+-      72  -0.28   0.47       79      2.843      2.962      0.119      0.177     0.67
+-      73  -0.28   0.56       57      3.694      3.920      0.226      0.191     1.18
+-      74  -0.28   0.65       13      4.687      5.052      0.365      0.257     1.42
+-      75  -0.19  -0.65       20      4.349      4.617      0.267      0.272     0.98
+-      76  -0.19  -0.56       64      3.217      3.484      0.268      0.188     1.42
+-      77  -0.19  -0.47       80      2.486      2.526      0.040      0.178     0.23
+-      78  -0.19  -0.37      103      1.671      1.742      0.071      0.169     0.42
+-      79  -0.19  -0.28       85      1.221      1.132     -0.088      0.168     0.53
+-      80  -0.19  -0.19       85      0.780      0.697     -0.083      0.164     0.50
+-      81  -0.19  -0.09       93      0.611      0.436     -0.176      0.164     1.07
+-      82  -0.19   0.00       93      0.274      0.348      0.075      0.154     0.49
+-      83  -0.19   0.09       91      0.419      0.436      0.017      0.157     0.11
+-      84  -0.19   0.19      100      0.726      0.697     -0.030      0.163     0.18
+-      85  -0.19   0.28       86      0.999      1.132      0.134      0.162     0.82
+-      86  -0.19   0.37       83      1.578      1.742      0.165      0.166     0.99
+-      87  -0.19   0.47      103      2.382      2.526      0.144      0.174     0.83
+-      88  -0.19   0.56       66      3.468      3.484      0.016      0.197     0.08
+-      89  -0.19   0.65       28      5.018      4.617     -0.401      0.340     1.18
+-      90  -0.09  -0.65       13      4.124      4.356      0.231      0.265     0.87
+-      91  -0.09  -0.56       42      3.331      3.223     -0.108      0.204     0.53
+-      92  -0.09  -0.47       81      2.131      2.265      0.134      0.172     0.78
+-      93  -0.09  -0.37       96      1.289      1.481      0.192      0.162     1.19
+-      94  -0.09  -0.28       87      0.907      0.871     -0.036      0.165     0.22
+-      95  -0.09  -0.19       77      0.413      0.436      0.023      0.157     0.14
+-      96  -0.09  -0.09       91      0.181      0.174     -0.007      0.153     0.05
+-      97  -0.09   0.00       93      0.017      0.087      0.070      0.149     0.47
+-      98  -0.09   0.09      107      0.063      0.174      0.111      0.150     0.74
+-      99  -0.09   0.19       94      0.573      0.436     -0.138      0.164     0.84
+-     100  -0.09   0.28       97      0.759      0.871      0.112      0.160     0.70
+-     101  -0.09   0.37       90      1.412      1.481      0.069      0.167     0.42
+-     102  -0.09   0.47       82      2.166      2.265      0.099      0.171     0.58
+-     103  -0.09   0.56       53      3.270      3.223     -0.047      0.197     0.24
+-     104  -0.09   0.65       24      4.290      4.356      0.065      0.277     0.24
+-     105   0.00  -0.65       20      4.606      4.268     -0.338      0.322     1.05
+-     106   0.00  -0.56       65      2.982      3.136      0.154      0.188     0.82
+-     107   0.00  -0.47      103      2.125      2.178      0.053      0.173     0.31
+-     108   0.00  -0.37       78      1.424      1.394     -0.030      0.168     0.18
+-     109   0.00  -0.28      106      0.639      0.784      0.145      0.157     0.92
+-     110   0.00  -0.19      100      0.312      0.348      0.037      0.156     0.24
+-     111   0.00  -0.09       98      0.053      0.087      0.034      0.150     0.23
+-     112   0.00   0.00       90      0.000      0.000      0.034      0.000     0.00
+-     113   0.00   0.09      102      0.198      0.087     -0.111      0.156     0.71
+-     114   0.00   0.19      110      0.251      0.348      0.098      0.155     0.63
+-     115   0.00   0.28       95      0.621      0.784      0.163      0.158     1.03
+-     116   0.00   0.37       92      1.341      1.394      0.053      0.167     0.32
+-     117   0.00   0.47       92      2.150      2.178      0.028      0.175     0.16
+-     118   0.00   0.56       67      3.042      3.136      0.094      0.191     0.49
+-     119   0.00   0.65       20      4.162      4.268      0.106      0.270     0.39
+-     120   0.09  -0.65       24      4.199      4.356      0.156      0.271     0.58
+-     121   0.09  -0.56       65      3.078      3.223      0.145      0.188     0.77
+-     122   0.09  -0.47       76      2.287      2.265     -0.022      0.175     0.13
+-     123   0.09  -0.37       80      1.486      1.481     -0.005      0.167     0.03
+-     124   0.09  -0.28       84      0.845      0.871      0.027      0.162     0.16
+-     125   0.09  -0.19       92      0.415      0.436      0.021      0.158     0.13
+-     126   0.09  -0.09      101     -0.017      0.174      0.192      0.148     1.30
+-     127   0.09   0.00       80     -0.075      0.087      0.162      0.147     1.11
+-     128   0.09   0.09       90      0.134      0.174      0.041      0.154     0.26
+-     129   0.09   0.19       79      0.287      0.436      0.149      0.155     0.96
+-     130   0.09   0.28      100      0.603      0.871      0.268      0.156     1.72
+-     131   0.09   0.37       91      1.500      1.481     -0.019      0.170     0.11
+-     132   0.09   0.47       89      2.278      2.265     -0.013      0.176     0.07
+-     133   0.09   0.56       53      3.139      3.223      0.084      0.193     0.44
+-     134   0.09   0.65       24      3.956      4.356      0.400      0.254     1.58
+-     135   0.19  -0.65       19      4.597      4.617      0.020      0.285     0.07
+-     136   0.19  -0.56       44      3.373      3.484      0.111      0.192     0.58
+-     137   0.19  -0.47       93      2.608      2.526     -0.081      0.180     0.45
+-     138   0.19  -0.37      121      1.736      1.742      0.006      0.169     0.03
+-     139   0.19  -0.28       85      1.014      1.132      0.119      0.161     0.74
+-     140   0.19  -0.19       86      0.546      0.697      0.151      0.158     0.95
+-     141   0.19  -0.09       77      0.345      0.436      0.091      0.156     0.58
+-     142   0.19   0.00       96      0.096      0.348      0.253      0.150     1.68
+-     143   0.19   0.09       98      0.486      0.436     -0.050      0.163     0.31
+-     144   0.19   0.19      104      0.469      0.697      0.228      0.157     1.45
+-     145   0.19   0.28       89      1.073      1.132      0.060      0.165     0.36
+-     146   0.19   0.37       81      1.820      1.742     -0.078      0.175     0.44
+-     147   0.19   0.47      105      2.264      2.526      0.262      0.170     1.55
+-     148   0.19   0.56       58      3.437      3.484      0.047      0.198     0.24
+-     149   0.19   0.65       20      4.316      4.617      0.301      0.267     1.13
+-     150   0.28  -0.65       18      5.288      5.052     -0.236      0.318     0.74
+-     151   0.28  -0.56       54      3.642      3.920      0.278      0.189     1.47
+-     152   0.28  -0.47      101      2.714      2.962      0.248      0.172     1.44
+-     153   0.28  -0.37      105      2.179      2.178     -0.001      0.173     0.00
+-     154   0.28  -0.28       95      1.496      1.568      0.072      0.167     0.43
+-     155   0.28  -0.19       97      1.175      1.132     -0.043      0.167     0.25
+-     156   0.28  -0.09       97      0.748      0.871      0.123      0.160     0.77
+-     157   0.28   0.00      101      0.692      0.784      0.092      0.161     0.57
+-     158   0.28   0.09      111      0.664      0.871      0.207      0.159     1.30
+-     159   0.28   0.19       90      1.059      1.132      0.073      0.166     0.44
+-     160   0.28   0.28      100      1.338      1.568      0.230      0.164     1.40
+-     161   0.28   0.37       98      1.960      2.178      0.218      0.169     1.29
+-     162   0.28   0.47       77      2.638      2.962      0.324      0.173     1.88
+-     163   0.28   0.56       53      3.970      3.920     -0.050      0.206     0.24
+-     164   0.28   0.65       29      4.980      5.052      0.073      0.296     0.25
+-     165   0.37  -0.65       22      5.502      5.662      0.160      0.283     0.56
+-     166   0.37  -0.56       51      4.306      4.530      0.223      0.194     1.15
+-     167   0.37  -0.47       78      3.375      3.572      0.197      0.177     1.11
+-     168   0.37  -0.37       97      2.677      2.788      0.111      0.173     0.64
+-     169   0.37  -0.28       91      2.176      2.178      0.002      0.172     0.01
+-     170   0.37  -0.19      100      1.801      1.742     -0.059      0.173     0.34
+-     171   0.37  -0.09       92      1.424      1.481      0.057      0.167     0.34
+-     172   0.37   0.00       90      1.294      1.394      0.100      0.166     0.60
+-     173   0.37   0.09       83      1.352      1.481      0.129      0.167     0.77
+-     174   0.37   0.19       77      1.727      1.742      0.015      0.173     0.09
+-     175   0.37   0.28       96      1.953      2.178      0.225      0.169     1.33
+-     176   0.37   0.37       94      2.587      2.788      0.200      0.174     1.15
+-     177   0.37   0.47       91      3.318      3.572      0.253      0.179     1.42
+-     178   0.37   0.56       63      4.311      4.530      0.219      0.200     1.09
+-     179   0.37   0.65       21      5.326      5.662      0.336      0.277     1.21
+-     180   0.47  -0.65       17      6.581      6.446     -0.135      0.327     0.41
+-     181   0.47  -0.56       63      5.137      5.314      0.177      0.206     0.86
+-     182   0.47  -0.47       81      4.516      4.356     -0.160      0.196     0.82
+-     183   0.47  -0.37       79      3.531      3.572      0.040      0.183     0.22
+-     184   0.47  -0.28       86      2.929      2.962      0.033      0.180     0.18
+-     185   0.47  -0.19       89      2.246      2.526      0.280      0.169     1.66
+-     186   0.47  -0.09       90      2.225      2.265      0.040      0.174     0.23
+-     187   0.47   0.00       82      1.985      2.178      0.192      0.171     1.13
+-     188   0.47   0.09       78      2.071      2.265      0.194      0.172     1.13
+-     189   0.47   0.19      102      2.095      2.526      0.431      0.168     2.56
+-     190   0.47   0.28       98      2.873      2.962      0.089      0.181     0.49
+-     191   0.47   0.37       92      3.299      3.572      0.273      0.179     1.53
+-     192   0.47   0.47       68      4.240      4.356      0.115      0.194     0.59
+-     193   0.47   0.56       59      5.060      5.314      0.254      0.209     1.21
+-     194   0.47   0.65       26      6.003      6.446      0.443      0.275     1.61
+-     195   0.56  -0.65       10      7.326      7.404      0.079      0.347     0.23
+-     196   0.56  -0.56       30      6.374      6.272     -0.102      0.246     0.41
+-     197   0.56  -0.47       47      5.386      5.314     -0.072      0.213     0.34
+-     198   0.56  -0.37       57      4.247      4.530      0.282      0.191     1.48
+-     199   0.56  -0.28       64      3.844      3.920      0.076      0.196     0.38
+-     200   0.56  -0.19       53      3.221      3.484      0.264      0.187     1.41
+-     201   0.56  -0.09       51      3.156      3.223      0.067      0.195     0.34
+-     202   0.56   0.00       59      2.794      3.136      0.342      0.185     1.85
+-     203   0.56   0.09       56      3.081      3.223      0.142      0.195     0.73
+-     204   0.56   0.19       52      3.238      3.484      0.247      0.193     1.28
+-     205   0.56   0.28       47      3.776      3.920      0.144      0.199     0.73
+-     206   0.56   0.37       56      4.188      4.530      0.341      0.195     1.75
+-     207   0.56   0.47       51      4.922      5.314      0.392      0.203     1.93
+-     208   0.56   0.56       32      6.071      6.272      0.201      0.239     0.84
+-     209   0.56   0.65       15      7.230      7.404      0.174      0.360     0.48
+-     210   0.65  -0.65        3      8.421      8.537      0.116      0.527     0.22
+-     211   0.65  -0.56       20      7.120      7.404      0.285      0.315     0.90
+-     212   0.65  -0.47       21      6.137      6.446      0.309      0.275     1.12
+-     213   0.65  -0.37       20      6.225      5.662     -0.563      0.373     1.51
+-     214   0.65  -0.28       29      5.450      5.052     -0.397      0.326     1.22
+-     215   0.65  -0.19       14      4.495      4.617      0.122      0.279     0.44
+-     216   0.65  -0.09       24      4.253      4.356      0.103      0.275     0.37
+-     217   0.65   0.00       20      4.327      4.268     -0.059      0.304     0.19
+-     218   0.65   0.09       33      4.149      4.356      0.207      0.276     0.75
+-     219   0.65   0.19       21      4.480      4.617      0.137      0.285     0.48
+-     220   0.65   0.28       18      4.551      5.052      0.502      0.250     2.01
+-     221   0.65   0.37       28      5.277      5.662      0.385      0.289     1.33
+-     222   0.65   0.47       26      5.859      6.446      0.587      0.266     2.21
+-     223   0.65   0.56       13      7.047      7.404      0.357      0.332     1.08
+-     224   0.65   0.65        9      7.417      8.537      1.120      0.418     2.68
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 5.5e-10
++Computing free energy surface ...
++INFO:pymbar.mbar_solvers:Reached a solution to within tolerance with hybr
++INFO:pymbar.mbar_solvers:Solution found within tolerance!
++INFO:pymbar.mbar_solvers:Final gradient norm: 5.5e-10
++2D FES:
++197 counts out of 24500 counts not in any bin
++Uncertainties only calculated for histogram methods
++     bin      x      y        N     f_hist      f_kde       true   err_hist    err_kde         df   sigmas
++       1  -0.65  -0.65        5      8.474      8.312      8.537      0.063      0.224      0.472     0.13
++       2  -0.65  -0.56       15      7.562      7.317      7.404     -0.158      0.088      0.297     0.53
++       3  -0.65  -0.47       21      6.584      6.277      6.446     -0.137      0.169      0.256     0.54
++       4  -0.65  -0.37       36      5.346      5.279      5.662      0.316      0.383      0.214     1.48
++       5  -0.65  -0.28       24      4.689      4.738      5.052      0.364      0.314      0.202     1.80
++       6  -0.65  -0.19       21      4.321      4.354      4.617      0.296      0.263      0.206     1.44
++       7  -0.65  -0.09       30      4.255      4.215      4.356      0.100      0.140      0.216     0.46
++       8  -0.65   0.00       21      4.534      4.231      4.268     -0.265      0.037      0.246     1.08
++       9  -0.65   0.09       33      4.313      4.233      4.356      0.043      0.122      0.230     0.19
++      10  -0.65   0.19       32      4.647      4.513      4.617     -0.030      0.104      0.228     0.13
++      11  -0.65   0.28       39      4.920      4.843      5.052      0.132      0.209      0.222     0.60
++      12  -0.65   0.37       33      5.652      5.486      5.662      0.010      0.177      0.240     0.04
++      13  -0.65   0.47       20      6.437      6.299      6.446      0.009      0.147      0.249     0.04
++      14  -0.65   0.56       21      6.828      6.934      7.404      0.577      0.471      0.235     2.46
++      15  -0.65   0.65        3      8.716      8.216      8.537     -0.180      0.321      0.519     0.35
++      16  -0.56  -0.65       14      7.419      7.322      7.404     -0.014      0.083      0.292     0.05
++      17  -0.56  -0.56       57      6.165      6.058      6.272      0.107      0.214      0.183     0.59
++      18  -0.56  -0.47       89      5.115      5.097      5.314      0.199      0.217      0.161     1.24
++      19  -0.56  -0.37       98      4.516      4.345      4.530      0.014      0.185      0.161     0.09
++      20  -0.56  -0.28       94      3.754      3.711      3.920      0.166      0.209      0.155     1.07
++      21  -0.56  -0.19      103      3.376      3.259      3.484      0.109      0.226      0.154     0.71
++      22  -0.56  -0.09      101      3.119      3.055      3.223      0.105      0.168      0.151     0.69
++      23  -0.56   0.00       95      3.100      2.988      3.136      0.036      0.148      0.153     0.24
++      24  -0.56   0.09      100      3.027      2.999      3.223      0.196      0.224      0.147     1.33
++      25  -0.56   0.19       88      3.342      3.265      3.484      0.143      0.219      0.151     0.94
++      26  -0.56   0.28       86      3.715      3.680      3.920      0.205      0.240      0.151     1.36
++      27  -0.56   0.37       92      4.353      4.292      4.530      0.177      0.238      0.155     1.14
++      28  -0.56   0.47       92      5.242      5.054      5.314      0.072      0.260      0.166     0.43
++      29  -0.56   0.56       52      5.886      5.930      6.272      0.386      0.342      0.172     2.25
++      30  -0.56   0.65       18      7.437      7.181      7.404     -0.033      0.224      0.282     0.12
++      31  -0.47  -0.65       21      6.682      6.236      6.446     -0.236      0.211      0.255     0.92
++      32  -0.47  -0.56       91      5.154      5.111      5.314      0.159      0.203      0.162     0.98
++      33  -0.47  -0.47      129      4.165      4.073      4.356      0.190      0.283      0.148     1.29
++      34  -0.47  -0.37      149      3.317      3.241      3.572      0.255      0.331      0.140     1.82
++      35  -0.47  -0.28      132      2.731      2.692      2.962      0.231      0.269      0.137     1.69
++      36  -0.47  -0.19      137      2.306      2.308      2.526      0.220      0.218      0.135     1.63
++      37  -0.47  -0.09      150      2.086      2.108      2.265      0.178      0.157      0.134     1.33
++      38  -0.47   0.00      134      1.984      2.015      2.178      0.193      0.163      0.134     1.45
++      39  -0.47   0.09      166      2.067      2.087      2.265      0.198      0.178      0.133     1.49
++      40  -0.47   0.19      161      2.416      2.392      2.526      0.110      0.134      0.136     0.81
++      41  -0.47   0.28      126      2.776      2.744      2.962      0.185      0.218      0.137     1.35
++      42  -0.47   0.37      141      3.416      3.353      3.572      0.156      0.219      0.141     1.11
++      43  -0.47   0.47      119      4.198      4.137      4.356      0.158      0.219      0.147     1.08
++      44  -0.47   0.56      101      5.242      5.139      5.314      0.072      0.174      0.164     0.44
++      45  -0.47   0.65       27      6.350      6.183      6.446      0.096      0.263      0.232     0.41
++      46  -0.37  -0.65       33      5.271      5.250      5.662      0.391      0.412      0.208     1.88
++      47  -0.37  -0.56       82      4.338      4.316      4.530      0.192      0.213      0.155     1.24
++      48  -0.37  -0.47      154      3.373      3.317      3.572      0.198      0.254      0.141     1.41
++      49  -0.37  -0.37      182      2.428      2.450      2.788      0.359      0.337      0.133     2.71
++      50  -0.37  -0.28      161      1.893      1.958      2.178      0.284      0.220      0.131     2.17
++      51  -0.37  -0.19      153      1.534      1.551      1.742      0.208      0.191      0.131     1.59
++      52  -0.37  -0.09      137      1.347      1.334      1.481      0.134      0.147      0.130     1.03
++      53  -0.37   0.00      150      1.198      1.259      1.394      0.195      0.135      0.129     1.52
++      54  -0.37   0.09      123      1.355      1.404      1.481      0.125      0.077      0.130     0.96
++      55  -0.37   0.19      168      1.728      1.685      1.742      0.014      0.057      0.134     0.11
++      56  -0.37   0.28      148      1.961      1.993      2.178      0.217      0.185      0.132     1.65
++      57  -0.37   0.37      175      2.630      2.633      2.788      0.158      0.155      0.136     1.16
++      58  -0.37   0.47      150      3.602      3.507      3.572     -0.031      0.065      0.146     0.21
++      59  -0.37   0.56       92      4.495      4.401      4.530      0.035      0.129      0.159     0.22
++      60  -0.37   0.65       24      5.364      5.360      5.662      0.299      0.302      0.215     1.39
++      61  -0.28  -0.65       37      5.109      4.865      5.052     -0.056      0.187      0.236     0.24
++      62  -0.28  -0.56       89      3.771      3.742      3.920      0.149      0.178      0.153     0.97
++      63  -0.28  -0.47      155      2.843      2.789      2.962      0.119      0.173      0.140     0.85
++      64  -0.28  -0.37      175      1.980      1.976      2.178      0.198      0.201      0.133     1.49
++      65  -0.28  -0.28      143      1.471      1.424      1.568      0.097      0.144      0.133     0.73
++      66  -0.28  -0.19      161      0.978      0.985      1.132      0.154      0.147      0.129     1.20
++      67  -0.28  -0.09      177      0.702      0.754      0.871      0.169      0.117      0.126     1.35
++      68  -0.28   0.00      140      0.544      0.664      0.784      0.240      0.120      0.123     1.94
++      69  -0.28   0.09      168      0.853      0.821      0.871      0.018      0.051      0.129     0.14
++      70  -0.28   0.19      166      1.073      1.089      1.132      0.060      0.043      0.129     0.46
++      71  -0.28   0.28      162      1.359      1.385      1.568      0.209      0.183      0.129     1.63
++      72  -0.28   0.37      154      2.041      2.028      2.178      0.137      0.150      0.134     1.02
++      73  -0.28   0.47      154      2.872      2.867      2.962      0.090      0.095      0.140     0.64
++      74  -0.28   0.56      102      3.679      3.740      3.920      0.241      0.180      0.149     1.61
++      75  -0.28   0.65       30      4.693      4.677      5.052      0.359      0.375      0.204     1.77
++      76  -0.19  -0.65       34      4.848      4.483      4.617     -0.231      0.134      0.247     0.94
++      77  -0.19  -0.56       89      3.230      3.242      3.484      0.254      0.243      0.149     1.71
++      78  -0.19  -0.47      154      2.411      2.385      2.526      0.115      0.141      0.138     0.83
++      79  -0.19  -0.37      158      1.588      1.587      1.742      0.155      0.155      0.132     1.17
++      80  -0.19  -0.28      155      0.936      0.977      1.132      0.196      0.156      0.128     1.54
++      81  -0.19  -0.19      151      0.596      0.584      0.697      0.101      0.113      0.127     0.79
++      82  -0.19  -0.09      179      0.310      0.354      0.436      0.126      0.081      0.123     1.02
++      83  -0.19   0.00      174      0.250      0.309      0.348      0.098      0.040      0.123     0.80
++      84  -0.19   0.09      143      0.352      0.363      0.436      0.084      0.072      0.123     0.68
++      85  -0.19   0.19      166      0.608      0.656      0.697      0.089      0.041      0.126     0.70
++      86  -0.19   0.28      157      1.095      1.075      1.132      0.037      0.057      0.130     0.29
++      87  -0.19   0.37      158      1.552      1.613      1.742      0.190      0.129      0.130     1.47
++      88  -0.19   0.47      135      2.531      2.420      2.526     -0.005      0.107      0.140     0.03
++      89  -0.19   0.56       83      3.424      3.361      3.484      0.061      0.123      0.154     0.39
++      90  -0.19   0.65       32      4.642      4.382      4.617     -0.025      0.235      0.232     0.11
++      91  -0.09  -0.65       29      4.153      4.109      4.356      0.203      0.247      0.215     0.94
++      92  -0.09  -0.56       91      2.995      2.986      3.223      0.228      0.237      0.148     1.54
++      93  -0.09  -0.47      149      2.054      2.093      2.265      0.211      0.172      0.134     1.57
++      94  -0.09  -0.37      155      1.437      1.322      1.481      0.044      0.159      0.133     0.33
++      95  -0.09  -0.28      161      0.601      0.660      0.871      0.270      0.211      0.123     2.19
++      96  -0.09  -0.19      157      0.135      0.239      0.436      0.300      0.197      0.119     2.52
++      97  -0.09  -0.09      158      0.034      0.058      0.174      0.140      0.116      0.119     1.18
++      98  -0.09   0.00      166     -0.007      0.068      0.087      0.094      0.020      0.118     0.80
++      99  -0.09   0.09      151      0.113      0.187      0.174      0.061     -0.013      0.120     0.51
++     100  -0.09   0.19      164      0.401      0.473      0.436      0.035     -0.037      0.124     0.28
++     101  -0.09   0.28      162      0.842      0.869      0.871      0.029      0.002      0.127     0.23
++     102  -0.09   0.37      152      1.431      1.406      1.481      0.050      0.075      0.130     0.38
++     103  -0.09   0.47      133      2.208      2.118      2.265      0.056      0.147      0.137     0.41
++     104  -0.09   0.56      113      2.936      3.003      3.223      0.287      0.220      0.145     1.98
++     105  -0.09   0.65       29      4.070      4.086      4.356      0.285      0.270      0.205     1.39
++     106   0.00  -0.65       21      4.431      4.112      4.268     -0.163      0.156      0.246     0.66
++     107   0.00  -0.56       87      2.982      2.893      3.136      0.154      0.243      0.150     1.03
++     108   0.00  -0.47      153      2.115      2.023      2.178      0.063      0.155      0.137     0.46
++     109   0.00  -0.37      162      1.319      1.326      1.394      0.075      0.068      0.131     0.57
++     110   0.00  -0.28      173      0.767      0.686      0.784      0.017      0.098      0.129     0.13
++     111   0.00  -0.19      154      0.103      0.198      0.348      0.245      0.151      0.119     2.06
++     112   0.00  -0.09      156     -0.104     -0.035      0.087      0.191      0.122      0.116     1.65
++     113   0.00   0.00      142      0.000      0.000      0.000      0.191      0.000      0.000     0.00
++     114   0.00   0.09      157      0.102      0.140      0.087     -0.015     -0.053      0.121     0.13
++     115   0.00   0.19      157      0.349      0.355      0.348     -0.001     -0.007      0.124     0.01
++     116   0.00   0.28      166      0.733      0.745      0.784      0.051      0.039      0.127     0.40
++     117   0.00   0.37      146      1.300      1.342      1.394      0.094      0.051      0.131     0.72
++     118   0.00   0.47      148      2.129      2.051      2.178      0.049      0.127      0.138     0.35
++     119   0.00   0.56      106      2.876      2.879      3.136      0.260      0.257      0.147     1.77
++     120   0.00   0.65       42      4.197      4.035      4.268      0.071      0.233      0.220     0.32
++     121   0.09  -0.65       25      4.097      4.086      4.356      0.259      0.269      0.206     1.25
++     122   0.09  -0.56      102      2.990      2.917      3.223      0.233      0.306      0.148     1.58
++     123   0.09  -0.47      155      1.963      2.062      2.265      0.302      0.203      0.131     2.30
++     124   0.09  -0.37      155      1.547      1.447      1.481     -0.066      0.034      0.137     0.48
++     125   0.09  -0.28      141      0.648      0.745      0.871      0.224      0.126      0.125     1.80
++     126   0.09  -0.19      156      0.359      0.320      0.436      0.077      0.116      0.125     0.61
++     127   0.09  -0.09      153      0.060      0.060      0.174      0.114      0.115      0.120     0.95
++     128   0.09   0.00      142     -0.034      0.030      0.087      0.121      0.057      0.118     1.03
++     129   0.09   0.09      160      0.046      0.118      0.174      0.129      0.057      0.119     1.08
++     130   0.09   0.19      146      0.305      0.366      0.436      0.131      0.070      0.122     1.07
++     131   0.09   0.28      145      0.826      0.819      0.871      0.045      0.052      0.128     0.35
++     132   0.09   0.37      175      1.416      1.409      1.481      0.065      0.071      0.132     0.49
++     133   0.09   0.47      144      1.986      2.049      2.265      0.279      0.216      0.133     2.10
++     134   0.09   0.56       88      3.063      2.981      3.223      0.160      0.242      0.151     1.06
++     135   0.09   0.65       27      4.000      3.996      4.356      0.356      0.359      0.205     1.74
++     136   0.19  -0.65       26      4.380      4.333      4.617      0.237      0.284      0.211     1.13
++     137   0.19  -0.56       97      3.377      3.242      3.484      0.107      0.242      0.154     0.70
++     138   0.19  -0.47      147      2.243      2.276      2.526      0.284      0.250      0.134     2.12
++     139   0.19  -0.37      143      1.499      1.531      1.742      0.243      0.211      0.130     1.88
++     140   0.19  -0.28      154      0.903      0.941      1.132      0.229      0.192      0.127     1.80
++     141   0.19  -0.19      155      0.468      0.548      0.697      0.229      0.149      0.124     1.84
++     142   0.19  -0.09      153      0.220      0.295      0.436      0.215      0.141      0.121     1.77
++     143   0.19   0.00      146      0.198      0.221      0.348      0.151      0.127      0.122     1.24
++     144   0.19   0.09      161      0.371      0.346      0.436      0.064      0.089      0.125     0.52
++     145   0.19   0.19      182      0.412      0.527      0.697      0.285      0.170      0.122     2.33
++     146   0.19   0.28      154      0.968      0.974      1.132      0.165      0.158      0.128     1.28
++     147   0.19   0.37      139      1.585      1.563      1.742      0.157      0.179      0.132     1.19
++     148   0.19   0.47      128      2.221      2.232      2.526      0.305      0.294      0.134     2.27
++     149   0.19   0.56       96      3.231      3.204      3.484      0.254      0.281      0.151     1.68
++     150   0.19   0.65       24      3.995      4.149      4.617      0.622      0.468      0.190     3.27
++     151   0.28  -0.65       29      4.574      4.635      5.052      0.478      0.417      0.199     2.40
++     152   0.28  -0.56      100      3.862      3.720      3.920      0.058      0.200      0.157     0.37
++     153   0.28  -0.47      151      2.898      2.793      2.962      0.063      0.169      0.142     0.45
++     154   0.28  -0.37      169      2.020      1.969      2.178      0.158      0.209      0.135     1.17
++     155   0.28  -0.28      170      1.337      1.356      1.568      0.231      0.212      0.130     1.78
++     156   0.28  -0.19      148      0.973      0.978      1.132      0.159      0.154      0.128     1.24
++     157   0.28  -0.09      153      0.690      0.738      0.871      0.181      0.133      0.126     1.44
++     158   0.28   0.00      151      0.567      0.617      0.784      0.217      0.167      0.124     1.74
++     159   0.28   0.09      146      0.795      0.776      0.871      0.076      0.095      0.128     0.59
++     160   0.28   0.19      156      0.983      1.011      1.132      0.149      0.121      0.129     1.16
++     161   0.28   0.28      161      1.360      1.417      1.568      0.208      0.151      0.130     1.60
++     162   0.28   0.37      165      1.950      1.970      2.178      0.228      0.208      0.134     1.71
++     163   0.28   0.47      157      2.730      2.685      2.962      0.232      0.276      0.138     1.68
++     164   0.28   0.56      103      3.544      3.592      3.920      0.376      0.328      0.149     2.52
++     165   0.28   0.65       30      4.920      4.812      5.052      0.132      0.241      0.227     0.58
++     166   0.37  -0.65       24      5.351      5.301      5.662      0.311      0.362      0.212     1.47
++     167   0.37  -0.56      100      4.359      4.307      4.530      0.170      0.223      0.157     1.08
++     168   0.37  -0.47      149      3.404      3.369      3.572      0.167      0.203      0.142     1.18
++     169   0.37  -0.37      162      2.489      2.528      2.788      0.299      0.260      0.133     2.24
++     170   0.37  -0.28      155      2.022      1.992      2.178      0.156      0.186      0.134     1.17
++     171   0.37  -0.19      169      1.559      1.603      1.742      0.183      0.139      0.131     1.40
++     172   0.37  -0.09      156      1.338      1.345      1.481      0.143      0.136      0.130     1.10
++     173   0.37   0.00      153      1.290      1.249      1.394      0.104      0.145      0.132     0.79
++     174   0.37   0.09      144      1.190      1.296      1.481      0.291      0.184      0.127     2.29
++     175   0.37   0.19      155      1.717      1.611      1.742      0.025      0.131      0.135     0.19
++     176   0.37   0.28      155      1.915      1.937      2.178      0.263      0.241      0.132     1.99
++     177   0.37   0.37      158      2.533      2.532      2.788      0.255      0.255      0.136     1.87
++     178   0.37   0.47      144      3.299      3.247      3.572      0.272      0.325      0.141     1.93
++     179   0.37   0.56       80      4.150      4.114      4.530      0.380      0.416      0.152     2.51
++     180   0.37   0.65       34      5.542      5.440      5.662      0.120      0.223      0.226     0.53
++     181   0.47  -0.65       23      6.572      6.243      6.446     -0.126      0.203      0.259     0.49
++     182   0.47  -0.56       80      5.147      5.095      5.314      0.167      0.219      0.161     1.04
++     183   0.47  -0.47      135      4.298      4.183      4.356      0.058      0.173      0.150     0.39
++     184   0.47  -0.37      125      3.356      3.283      3.572      0.215      0.288      0.140     1.53
++     185   0.47  -0.28      138      2.765      2.762      2.962      0.197      0.200      0.137     1.44
++     186   0.47  -0.19      129      2.407      2.411      2.526      0.119      0.115      0.138     0.86
++     187   0.47  -0.09      134      2.206      2.093      2.265      0.059      0.172      0.137     0.43
++     188   0.47   0.00      129      1.969      1.990      2.178      0.209      0.188      0.134     1.56
++     189   0.47   0.09      157      2.105      2.078      2.265      0.160      0.187      0.135     1.18
++     190   0.47   0.19      157      2.467      2.382      2.526      0.059      0.144      0.140     0.42
++     191   0.47   0.28      144      2.696      2.693      2.962      0.266      0.268      0.136     1.95
++     192   0.47   0.37      147      3.349      3.279      3.572      0.223      0.293      0.141     1.58
++     193   0.47   0.47      141      4.035      3.979      4.356      0.321      0.376      0.145     2.21
++     194   0.47   0.56       91      5.030      4.865      5.314      0.284      0.449      0.162     1.75
++     195   0.47   0.65       28      6.238      6.016      6.446      0.208      0.430      0.233     0.90
++     196   0.56  -0.65       27      7.119      7.064      7.404      0.286      0.341      0.256     1.12
++     197   0.56  -0.56       74      6.185      5.965      6.272      0.087      0.307      0.187     0.46
++     198   0.56  -0.47       85      5.049      5.039      5.314      0.265      0.275      0.158     1.68
++     199   0.56  -0.37       87      4.417      4.306      4.530      0.113      0.224      0.158     0.72
++     200   0.56  -0.28      107      3.699      3.682      3.920      0.221      0.238      0.151     1.47
++     201   0.56  -0.19       89      3.457      3.372      3.484      0.028      0.112      0.156     0.18
++     202   0.56  -0.09      109      2.856      2.918      3.223      0.367      0.305      0.144     2.55
++     203   0.56   0.00      105      2.844      2.826      3.136      0.292      0.310      0.146     2.00
++     204   0.56   0.09       92      3.119      2.997      3.223      0.104      0.226      0.153     0.68
++     205   0.56   0.19       96      3.296      3.290      3.484      0.189      0.194      0.151     1.25
++     206   0.56   0.28      107      3.644      3.654      3.920      0.276      0.266      0.150     1.84
++     207   0.56   0.37      109      4.477      4.281      4.530      0.052      0.248      0.163     0.32
++     208   0.56   0.47       88      5.042      4.968      5.314      0.271      0.345      0.161     1.69
++     209   0.56   0.56       54      6.078      5.880      6.272      0.194      0.392      0.186     1.05
++     210   0.56   0.65       17      7.255      6.981      7.404      0.149      0.423      0.283     0.53
++     211   0.65  -0.65        4      9.030      8.347      8.537     -0.493      0.190      0.600     0.82
++     212   0.65  -0.56       16      7.259      7.077      7.404      0.145      0.328      0.271     0.54
++     213   0.65  -0.47       27      6.285      6.125      6.446      0.161      0.321      0.232     0.69
++     214   0.65  -0.37       33      5.601      5.410      5.662      0.061      0.253      0.238     0.26
++     215   0.65  -0.28       37      4.853      4.734      5.052      0.199      0.318      0.218     0.92
++     216   0.65  -0.19       25      4.379      4.289      4.617      0.238      0.328      0.211     1.13
++     217   0.65  -0.09       34      4.192      4.052      4.356      0.164      0.304      0.217     0.75
++     218   0.65   0.00       28      3.757      3.881      4.268      0.511      0.387      0.190     2.69
++     219   0.65   0.09       34      4.290      4.089      4.356      0.065      0.267      0.223     0.29
++     220   0.65   0.19       43      4.689      4.431      4.617     -0.072      0.186      0.235     0.31
++     221   0.65   0.28       27      4.865      4.782      5.052      0.188      0.270      0.218     0.86
++     222   0.65   0.37       28      5.274      5.324      5.662      0.389      0.338      0.210     1.85
++     223   0.65   0.47       27      6.269      6.083      6.446      0.177      0.363      0.227     0.78
++     224   0.65   0.56       16      7.225      6.987      7.404      0.179      0.417      0.277     0.65
++     225   0.65   0.65        4      8.538      8.203      8.537     -0.001      0.334      0.520     0.00


### PR DESCRIPTION
pymbar 3.1.1 and 4.0.2 builds

There is an API change between the 3.x and 4.x versions, with long term support promised for the earlier version.

    Includes numexpr version 2.8.1

Tony