### PR TITLE
HyPhy version 2.5.58

### DIFF
--- a/config/easybuild/easyconfigs/HyPhy-2.5.58-gompi-2021b.eb
+++ b/config/easybuild/easyconfigs/HyPhy-2.5.58-gompi-2021b.eb
@@ -1,0 +1,42 @@
+# This file is an EasyBuild reciPY as per https://easybuilders.github.io/easybuild/
+
+easyblock = "CMakeMake"
+
+name = 'HyPhy'
+version = '2.5.58'
+
+homepage = 'https://veg.github.io/hyphy-site/'
+description = """HyPhy (Hypothesis Testing using Phylogenies) is an open-source software package 
+ for the analysis of genetic sequences (in particular the inference of natural selection) 
+ using techniques in phylogenetics, molecular evolution, and machine learning"""
+
+toolchain = {'name': 'gompi', 'version': '2021b'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = ['https://github.com/veg/hyphy/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['f448d4a95bdb356eb6b1384b0c507a79f152511ad76bb67170ab5b8eb2798231']
+
+builddependencies = [('CMake', '3.22.1')]
+
+dependencies = [
+    ('cURL', '7.78.0'),
+]
+
+buildopts = [
+    'hyphy',
+    'HYPHYMPI',
+    # GTEST seems to have been replaced by test
+    #'GTEST',
+    # ...but test doesn't build!
+    #'test',
+]
+
+#runtest = "test"
+
+sanity_check_paths = {
+    'files': ['bin/hyphy', 'bin/HYPHYMPI'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/config/easybuild/easyconfigs/HyPhy-2.5.59-gompi-2021b.eb
+++ b/config/easybuild/easyconfigs/HyPhy-2.5.59-gompi-2021b.eb
@@ -1,0 +1,42 @@
+# This file is an EasyBuild reciPY as per https://easybuilders.github.io/easybuild/
+
+easyblock = "CMakeMake"
+
+name = 'HyPhy'
+version = '2.5.59'
+
+homepage = 'https://veg.github.io/hyphy-site/'
+description = """HyPhy (Hypothesis Testing using Phylogenies) is an open-source software package 
+ for the analysis of genetic sequences (in particular the inference of natural selection) 
+ using techniques in phylogenetics, molecular evolution, and machine learning"""
+
+toolchain = {'name': 'gompi', 'version': '2021b'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = ['https://github.com/veg/hyphy/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['4c25fa94c8284c5b4b609fad42b1ce34e66775280aa8e00c48adb7dd2ba29927']
+
+builddependencies = [('CMake', '3.22.1')]
+
+dependencies = [
+    ('cURL', '7.78.0'),
+]
+
+buildopts = [
+    'hyphy',
+    'HYPHYMPI',
+    # GTEST seems to have been replaced by test
+    #'GTEST',
+    # ...but test doesn't build!
+    #'test',
+]
+
+#runtest = "test"
+
+sanity_check_paths = {
+    'files': ['bin/hyphy', 'bin/HYPHYMPI'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
HyPhy version 2.5.58

I can’t get the tests to run at all - the “run_unit_tests.sh” file (likely amongst others)
is not copied from the source tree to the […]/easybuild_obj build dir.

Super minimal tests:
```
$ module load gcc/11.2.0 openmpi/4.1.1 hyphy/2.5.58
$ hyphy gard --help
[,,,]
$ hyphy acd --help
[...]
$ HYPHYMPI --help
[...]
$ 
```

Tony