### PR TITLE
OpenFOAM version 2206

### DIFF
--- a/config/easybuild/easyconfigs/KaHIP-3.14-gompi-2021b.eb
+++ b/config/easybuild/easyconfigs/KaHIP-3.14-gompi-2021b.eb
@@ -1,0 +1,28 @@
+easyblock = 'CMakeMake'
+
+name = 'KaHIP'
+version = '3.14'
+
+homepage = 'https://kahip.github.io/'
+description = """The graph partitioning framework KaHIP -- Karlsruhe High Quality Partitioning."""
+
+toolchain = {'name': 'gompi', 'version': '2021b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/KaHIP/KaHIP/archive/refs/tags']
+sources = ['v%(version)s.tar.gz']
+checksums = ['9da04f3b0ea53b50eae670d6014ff54c0df2cb40f6679b2f6a96840c1217f242']
+
+builddependencies = [
+    ('binutils', '2.37'),
+    ('CMake', '3.22.1'),
+]
+
+sanity_check_paths = {
+    'files': ["lib/libkahip_static.a", "lib/libkahip.%s" % SHLIB_EXT] +
+             ["lib/libparhip_interface_static.a", "lib/libparhip_interface.%s" % SHLIB_EXT] +
+             ["include/%s" % x for x in ["kaHIP_interface.h", "parhip_interface.h"]],
+    'dirs': [],
+}
+
+moduleclass = 'math'

--- a/config/easybuild/easyconfigs/OpenFOAM-v2206-foss-2021b.eb
+++ b/config/easybuild/easyconfigs/OpenFOAM-v2206-foss-2021b.eb
@@ -43,4 +43,6 @@ dependencies = [
     ('gnuplot', '5.4.2'),
 ]
 
+modextrapaths = {'PATH': [ '%(name)s-%(version)s/bin', '%(name)s-%(version)s/bin/tools' ]}
+
 moduleclass = 'cae'

--- a/config/easybuild/easyconfigs/OpenFOAM-v2206-foss-2021b.eb
+++ b/config/easybuild/easyconfigs/OpenFOAM-v2206-foss-2021b.eb
@@ -1,0 +1,46 @@
+name = 'OpenFOAM'
+version = 'v2206'
+
+homepage = 'https://www.openfoam.com/'
+description = """OpenFOAM is a free, open source CFD software package.
+ OpenFOAM has an extensive range of features to solve anything from complex fluid flows
+ involving chemical reactions, turbulence and heat transfer,
+ to solid dynamics and electromagnetics."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+# Users have found that vectorizion caused OpenFOAM to produce some very incorrect results.
+# Disabling vectorize was confirmed to fix the the known issues.
+# With no test suite, sticking to known working toolchain options until proven otherwise.
+toolchainopts = {'cstd': 'c++11', 'vectorize': False}
+
+source_urls = ['https://sourceforge.net/projects/openfoam/files/%(version)s/']
+sources = [SOURCE_TGZ]
+patches = [
+    ('OpenFOAM-v2206-cleanup.patch', 1),
+    'OpenFOAM-v1906-wmake-ompi.patch',
+]
+checksums = [
+    'db95eda4afb97ca870733b2d4201ef539099d0778e3f3eca9a075d4f1a0eea46',  # OpenFOAM-v2206.tgz
+    '25333124581acae57c173587de4ebd6e143b894b1a26e4f0326db8b7e0cb1972',  # OpenFOAM-v2206-cleanup.patch
+    '518e27683c5c41400cfbc17b31effa50b31b25916dccbf85b18b0b955f642505',  # OpenFOAM-v1906-wmake-ompi.patch
+]
+
+builddependencies = [
+    ('Bison', '3.7.6'),
+    ('CMake', '3.21.1'),
+    ('flex', '2.6.4'),
+]
+
+dependencies = [
+    ('libreadline', '8.1'),
+    ('ncurses', '6.2'),
+    # OpenFOAM requires 64 bit METIS using 32 bit indexes (array indexes)
+    ('METIS', '5.1.0'),
+    ('SCOTCH', '7.0.2'),
+    ('KaHIP', '3.14'),
+    ('CGAL', '4.14.3'),
+    ('ParaView', '5.11.2'),
+    ('gnuplot', '5.4.2'),
+]
+
+moduleclass = 'cae'


### PR DESCRIPTION
OpenFOAM version 2206

Includes:
    KaHIP version 3.14
    CGAL version 4.14.3
    libcerf version 1.17
    gnuplot version 5.4.2

Tony