### PR TITLE
Added a read only mount of /projects to the container start schipt

### DIFF
--- a/start-container.sh
+++ b/start-container.sh
@@ -88,6 +88,10 @@ if [ -d "/util" ]; then
     SINGULARITY_BIND="${SINGULARITY_BIND},/util:/util:ro"
 fi
 
+if [ -d "/projects" ]; then
+    SINGULARITY_BIND="${SINGULARITY_BIND},/projects:/projects:ro"
+fi
+
 if [ -d "/etc/glvnd" ]; then
     SINGULARITY_BIND="${SINGULARITY_BIND},/etc/glvnd:/etc/glvnd:rw"
 fi


### PR DESCRIPTION
Added a read only mount of /projects to the container start script

I use a git update script /projects/ccrstaff/general/git/update_git_from_upstream_main
I don't have access to otherwise.

Tony