### PR TITLE
anvio version 7.1

### DIFF
--- a/config/easybuild/easyconfigs/anvio-7.1-foss-2021b-Python-3.9.6.eb
+++ b/config/easybuild/easyconfigs/anvio-7.1-foss-2021b-Python-3.9.6.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('SciPy-bundle', '2021.10'),
     ('Pysam', '0.18.0'),
     ('scikit-learn', '1.0.2'),
-    ('matplotlib', '3.4.3'),
+    ('matplotlib', '3.5.2'),
     ('prodigal', '2.6.3'),
     ('Biopython', '1.79'),
     ('h5py', '3.6.0'),

--- a/config/easybuild/easyconfigs/anvio-7.1-foss-2021b-Python-3.9.6.eb
+++ b/config/easybuild/easyconfigs/anvio-7.1-foss-2021b-Python-3.9.6.eb
@@ -1,0 +1,178 @@
+# Author: Pavel Grochal (INUITS)
+# License: GPLv2
+
+easyblock = 'PythonBundle'
+
+name = 'anvio'
+version = '7.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://merenlab.org/software/anvio/'
+description = """An analysis and visualization platform for 'omics data."""
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+toolchainopts = {'pic': True, 'usempi': True, 'openmp': True}
+
+github_account = 'merenlab'
+
+dependencies = [
+    ('Python', '3.9.6'),
+    ('SciPy-bundle', '2021.10'),
+    ('Pysam', '0.18.0'),
+    ('scikit-learn', '1.0.2'),
+    ('matplotlib', '3.4.3'),
+    ('prodigal', '2.6.3'),
+    ('Biopython', '1.79'),
+    ('h5py', '3.6.0'),
+    ('HMMER', '3.3.2'),
+    ('snakemake', '7.18.2'),
+    ('numba', '0.54.1'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('bottle', '0.12.17', {
+        'checksums': ['e9eaa412a60cc3d42ceb42f58d15864d9ed1b92e9d630b8130c871c5bb16107c'],
+    }),
+    ('ete3', '3.1.1', {
+        'checksums': ['870a3d4b496a36fbda4b13c7c6b9dfa7638384539ae93551ec7acb377fb9c385'],
+    }),
+    ('sqlparse', '0.3.0', {
+        'checksums': ['7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873'],
+    }),
+    ('Django', '2.2.7', {
+        'checksums': ['16040e1288c6c9f68c6da2fe75ebde83c0a158f6f5d54f4c5177b0c1478c5b86'],
+    }),
+    ('zc.lockfile', '2.0', {
+        'checksums': ['307ad78227e48be260e64896ec8886edc7eae22d8ec53e4d528ab5537a83203b'],
+    }),
+    ('jaraco.functools', '2.0', {
+        'checksums': ['35ba944f52b1a7beee8843a5aa6752d1d5b79893eeb7770ea98be6b637bf9345'],
+    }),
+    ('tempora', '1.14.1', {
+        'checksums': ['cb60b1d2b1664104e307f8e5269d7f4acdb077c82e35cd57246ae14a3427d2d6'],
+    }),
+    ('portend', '2.6', {
+        'checksums': ['600dd54175e17e9347e5f3d4217aa8bcf4bf4fa5ffbc4df034e5ec1ba7cdaff5'],
+    }),
+    ('cheroot', '8.2.1', {
+        'checksums': ['5b525b3e4a755adf78070ab54c1821fb860d4255a9317dba2b88eb2df2441cff'],
+    }),
+    ('CherryPy', '18.4.0', {
+        'checksums': ['e5be00304ca303d7791d14b5ce1436428e18939b91806250387c363ae56c8f8f'],
+    }),
+    ('mistune', '0.8.4', {
+        'checksums': ['59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e'],
+    }),
+    ('seaborn', '0.9.0', {
+        'checksums': ['76c83f794ca320fb6b23a7c6192d5e185a5fcf4758966a0c0a54baee46d41e2f'],
+    }),
+    ('pyani', '0.2.9', {
+        'checksums': ['0b87870a03cf5ccd8fbab7572778903212a051990f00cf8e4ef5887b36b9ec91'],
+    }),
+    ('patsy', '0.5.1', {
+        'checksums': ['f115cec4201e1465cd58b9866b0b0e7b941caafec129869057405bfe5b5e3991'],
+    }),
+    ('statsmodels', '0.10.1', {
+        'checksums': ['320659a80f916c2edf9dfbe83512d9004bb562b72eedb7d9374562038697fa10'],
+    }),
+    ('smmap2', '2.0.5', {
+        'modulename': 'smmap',
+        'checksums': ['29a9ffa0497e7f2be94ca0ed1ca1aa3cd4cf25a1f6b4f5f87f74b46ed91d609a'],
+    }),
+    ('gitdb2', '2.0.6', {
+        'modulename': 'gitdb',
+        'checksums': ['1b6df1433567a51a4a9c1a5a0de977aa351a405cc56d7d35f3388bad1f630350'],
+    }),
+    ('GitPython', '3.0.5', {
+        'modulename': 'git',
+        'checksums': ['9c2398ffc3dcb3c40b27324b316f08a4f93ad646d5a6328cafbb871aa79f5e42'],
+    }),
+    ('zipp', '3.17.0', {
+        'checksums': ['84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0'],
+    }),
+    ('importlib_metadata', '0.23', {
+        'checksums': ['aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26'],
+    }),
+    ('pyrsistent', '0.15.6', {
+        'checksums': ['f3b280d030afb652f79d67c5586157c5c1355c9a58dfc7940566e28d28f3df1b'],
+    }),
+    ('jsonschema', '3.2.0', {
+        'checksums': ['c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a'],
+    }),
+    ('datrie', '0.8.2', {
+        'checksums': ['525b08f638d5cf6115df6ccd818e5a01298cd230b2dac91c8ff2e6499d18765d'],
+    }),
+    ('appdirs', '1.4.3', {
+        'checksums': ['9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92'],
+    }),
+    ('ConfigArgParse', '0.15.1', {
+        'checksums': ['baaf0fd2c1c108d007f402dab5481ac5f12d77d034825bf5a27f8224757bd0ac'],
+    }),
+    ('PyYAML', '6.0.1', {
+        'modulename': 'yaml',
+        'checksums': ['bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43'],
+    }),
+    ('ratelimiter', '1.2.0.post0', {
+        'checksums': ['5c395dcabdbbde2e5178ef3f89b568a3066454a6ddc223b76473dac22f89b4f7'],
+    }),
+    ('wrapt', '1.11.2', {
+        'checksums': ['565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1'],
+    }),
+#    ('snakemake', '5.8.1', {
+#        'checksums': ['60c1d11d3a63397b6d91ef394639cb454d9965217747b60fafb5573a498838e4'],
+#    }),
+    ('colored', '1.4.0', {
+        'checksums': ['ee8f73c40c06d9e5b829a8e284ebfaeac5ebfc7578f2eb4a0e031b40fe799a72'],
+    }),
+    ('python-Levenshtein', '0.12.0', {
+        'modulename': 'Levenshtein',
+        'checksums': ['033a11de5e3d19ea25c9302d11224e1a1898fe5abd23c61c7c360c25195e3eb1'],
+    }),
+    ('illumina-utils', '2.13', {
+        'modulename': 'IlluminaUtils',
+        'checksums': ['e688ca221ea6178614073b72205fce7b4a54695237c7aa96713492ecd99bd56e'],
+    }),
+    ('more-itertools', '7.2.0', {
+        'checksums': ['409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832'],
+    }),
+    ('Paste', '3.7.1', {
+        'checksums': ['6d07a8e1c7fa72b8cf403762a002f80d12c0384056956dd0a87cb9a3be64749a'],
+    }),
+    (name, version, {
+        'source_urls': ['https://github.com/%(github_account)s/%(name)s/releases/download/v%(version)s/'],
+        'checksums': [
+            '5ff729ba392a530b200378cd55e0dd85032152da44dce0260daef2ddc3122c99',  # anvio-7.1.tar.gz
+        ],
+        # replace fixed (==) versions in requirements.txt with minimal versions (>=)
+        'preinstallopts': "sed -i'' 's/==/>=/g' requirements.txt && ",
+    }),
+]
+
+local_binaries_list = [
+    'anvi-pan-genome',
+    'anvi-script-reformat-fasta',
+    'anvi-profile',
+    'anvi-help',
+]
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in local_binaries_list],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = [
+    #
+    # The following command requires terminal access to send a <ctrl-c> to
+    # terminal the test server, so cannot be run as a sanity test here
+    # 
+    #'anvi-self-test --suite mini',
+    'anvi-pan-genome --help',
+    'anvi-script-reformat-fasta --help',
+    'anvi-profile --version',
+    'anvi-help --help',
+]
+
+moduleclass = 'bio'


### PR DESCRIPTION
anvio version 7.1 easyconfig file

After install, manually run the test suite, which requires an interactive
terminal to <ctrl-c> the test server process e.g.

    $ module load gcc/11.2.0 openmpi/4.1.1 anvio/7.1-Python-3.9.6
    $ anvi-self-test --suite mini

Tony