### PR TITLE
Aria2 & Roary EB files

### DIFF
--- a/config/easybuild/easyconfigs/CppUnit-1.15.1-GCCcore-11.2.0.eb
+++ b/config/easybuild/easyconfigs/CppUnit-1.15.1-GCCcore-11.2.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'CppUnit'
+version = '1.15.1'
+
+homepage = 'https://freedesktop.org/wiki/Software/cppunit/'
+
+description = """
+ CppUnit is the C++ port of the famous JUnit framework for unit testing.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
+
+source_urls = ['https://dev-www.libreoffice.org/src']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['89c5c6665337f56fd2db36bc3805a5619709d51fb136e51937072f63fcc717a7']
+
+builddependencies = [
+    ('binutils', '2.38'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/libcppunit.a', 'lib/libcppunit.%s' % SHLIB_EXT,
+              'lib/pkgconfig/cppunit.pc'],
+    'dirs': ['bin', 'include/cppunit', 'share'],
+}
+
+moduleclass = 'tools'

--- a/config/easybuild/easyconfigs/Kraken-1.1.1-GCCcore-11.2.0.eb
+++ b/config/easybuild/easyconfigs/Kraken-1.1.1-GCCcore-11.2.0.eb
@@ -1,0 +1,50 @@
+easyblock = 'PackedBinary'
+
+name = 'Kraken'
+version = '1.1.1'
+
+homepage = 'https://ccb.jhu.edu/software/%(namelower)s/'
+description = """Kraken is a system for assigning taxonomic labels to short DNA sequences,
+ usually obtained through metagenomic studies. Previous attempts by other
+ bioinformatics software to accomplish this task have often used sequence
+ alignment or machine learning techniques that were quite slow, leading to
+ the development of less sensitive but much faster abundance estimation
+ programs. Kraken aims to achieve high sensitivity and high speed by
+ utilizing exact alignments of k-mers and a novel classification algorithm."""
+
+# Part is compiled with CXX, the rest is in Perl
+toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
+toolchainopts = {'openmp': True}
+
+github_account = 'DerrickWood'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ['v%(version)s.tar.gz']
+patches = ['%(name)s-1.1_CXX-CXXFLAGS.patch']
+checksums = [
+    '73e48f40418f92b8cf036ca1da727ca3941da9b78d4c285b81ba3267326ac4ee',  # v1.1.1.tar.gz
+    '84c017d6a80ccaac1e23561c83cac90bcc3d62baa8d31657a7dafbc2c3f29726',  # Kraken-1.1.1_CXX-CXXFLAGS.patch
+]
+
+builddependencies = [
+    ('binutils', '2.38'),
+]
+
+dependencies = [
+    ('Perl', '5.34.0'),
+    ('wget', '1.21.2'),
+]
+
+install_cmd = 'cd %(builddir)s/%(namelower)s-%(version)s && '
+install_cmd += './install_%(namelower)s.sh %(installdir)s'
+
+sanity_check_paths = {
+    'files': ['add_to_library.sh', 'build_kraken_db.sh', 'check_for_jellyfish.sh', 'classify', 'clean_db.sh',
+              'cp_into_tempfile.pl', 'db_shrink', 'db_sort', 'download_genomic_library.sh',
+              'download_taxonomy.sh', 'kraken', 'kraken-build', 'kraken-filter', 'krakenlib.pm',
+              'kraken-mpa-report', 'kraken-report', 'kraken-translate', 'make_seqid_to_taxid_map',
+              'read_merger.pl', 'report_gi_numbers.pl', 'set_lcas', 'shrink_db.sh',
+              'standard_installation.sh', 'upgrade_db.sh', 'verify_gi_numbers.pl'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/config/easybuild/easyconfigs/MCL-14.137-GCCcore-11.2.0.eb
+++ b/config/easybuild/easyconfigs/MCL-14.137-GCCcore-11.2.0.eb
@@ -1,0 +1,41 @@
+easyblock = 'ConfigureMake'
+
+name = 'MCL'
+version = '14.137'
+
+homepage = 'https://micans.org/mcl/'
+description = """The MCL algorithm is short for the Markov Cluster Algorithm, a fast
+and scalable unsupervised cluster algorithm for graphs (also known as networks) based
+on simulation of (stochastic) flow in graphs. """
+
+toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
+
+source_urls = ['http://micans.org/%(namelower)s/src/']
+sources = ['%(namelower)s-%(version_major)s-%(version_minor)s.tar.gz']
+patches = ['%(name)s-%(version)s_fixperl.patch']
+checksums = [
+    'b5786897a8a8ca119eb355a5630806a4da72ea84243dba85b19a86f14757b497',  # mcl-14-137.tar.gz
+    '46988a287b2ee400a54fa485176d043b2a2d6589b6257cc6cf9c21689ea3842d',  # MCL-14.137_fixperl.patch
+]
+
+builddependencies = [
+    ('binutils', '2.35'),
+]
+
+dependencies = [
+    ('Perl', '5.34.0'),
+]
+
+preconfigopts = 'export CFLAGS="$CFLAGS -fcommon" && '
+configopts = '--enable-blast '
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['clm', 'clmformat', 'clxdo', 'mcl', 'mclblastline', 'mclcm', 'mclpipeline', 'mcx',
+                                     'mcxarray', 'mcxassemble', 'mcxdeblast', 'mcxdump', 'mcxi', 'mcxload', 'mcxmap',
+                                     'mcxrand', 'mcxsubs']],
+    'dirs': ['share']
+}
+
+sanity_check_commands = ["mcl --help"]
+
+moduleclass = 'bio'

--- a/config/easybuild/easyconfigs/Roary-3.13.0-foss-2021b.eb
+++ b/config/easybuild/easyconfigs/Roary-3.13.0-foss-2021b.eb
@@ -1,0 +1,48 @@
+easyblock = 'Tarball'
+
+name = 'Roary'
+version = '3.13.0'
+
+homepage = 'https://github.com/sanger-pathogens/Roary'
+description = "Rapid large-scale prokaryote pan genome analysis"
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+source_urls = ['https://github.com/sanger-pathogens/Roary/archive/']
+sources = ['v%(version)s.tar.gz']
+patches = ['Roary-3.13.0_fix-CD-HIT-regexp.patch']
+checksums = [
+    '375f83c8750b0f4dea5b676471e73e94f3710bc3a327ec88b59f25eae1c3a1e8',  # v3.13.0.tar.gz
+    '28b4176ebf20c7bc6f38fdf1cf7e71cae8bd823297543f93fbc28a0c1c3cf791',  # Roary-3.13.0_fix-CD-HIT-regexp.patch
+]
+
+dependencies = [
+    ('Perl', '5.34.0'),
+    ('CD-HIT', '4.8.1'),
+    ('BLAST+', '2.12.0'),
+    ('MCL', '14.137'),
+    ('BEDTools', '2.30.0'),
+    ('PRANK', '170427'),
+    ('parallel', '20210722'),
+    ('FastTree', '2.1.11'),
+    ('Kraken', '1.1.1'),
+    ('BioPerl', '1.7.8'),
+    ('R', '4.2.0'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/roary', 'lib/Bio/Roary.pm'],
+    'dirs': ['lib/Bio/Roary'],
+}
+
+modextrapaths = {'PERL5LIB': 'lib'}
+
+sanity_check_commands = [
+    "perldoc -lm Bio::Roary",
+    "roary -a",
+    # make sure all (optional) dependencies are found
+    # grep exits with '1' if no matches are found, hence we need to test the exit code ($?)
+    "roary -a 2>&1 | grep 'not found'; test $? -eq 1",
+]
+
+moduleclass = 'bio'

--- a/config/easybuild/easyconfigs/aria2-1.36.0-GCCcore-11.2.0.eb
+++ b/config/easybuild/easyconfigs/aria2-1.36.0-GCCcore-11.2.0.eb
@@ -1,0 +1,40 @@
+easyblock = 'ConfigureMake'
+
+name = 'aria2'
+version = '1.36.0'
+
+homepage = 'https://aria2.github.io'
+description = "aria2 is a lightweight multi-protocol & multi-source command-line download utility."
+
+toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
+
+source_urls = ['https://github.com/aria2/aria2/releases/download/release-%(version)s']
+sources = [SOURCE_TAR_GZ]
+checksums = ['b593b2fd382489909c96c62c6e180054c3332b950be3d73e0cb0d21ea8afb3c5']
+
+builddependencies = [
+    ('binutils', '2.38'),
+    ('Autotools', '20220317'),
+    ('CppUnit', '1.15.1'),
+]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('libxml2', '2.9.10'),
+    ('SQLite', '3.36'),
+    ('c-ares', '1.18.1'),
+    ('OpenSSL', '1.1', '', SYSTEM),
+]
+
+configopts = "--without-gnutls --with-openssl --enable-libaria2 --enable-static"
+
+runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['bin/aria2c'],
+    'dirs': ['share'],
+}
+
+sanity_check_commands = ["aria2c --help"]
+
+moduleclass = 'tools'

--- a/config/easybuild/easyconfigs/wget-1.21.2-GCCcore-11.2.0.eb
+++ b/config/easybuild/easyconfigs/wget-1.21.2-GCCcore-11.2.0.eb
@@ -1,0 +1,48 @@
+##
+# Author:    Robert Mijakovic <robert.mijakovic@lxp.lu>
+##
+easyblock = 'ConfigureMake'
+
+name = 'wget'
+version = '1.21.2'
+
+homepage = 'https://www.gnu.org/software/wget'
+description = """GNU Wget is a free software package for retrieving files using HTTP, HTTPS and FTP,
+ the most widely-used Internet protocols. It is a non-interactive commandline tool,
+ so it may easily be called from scripts, cron jobs, terminals without X-Windows support, etc."""
+
+toolchain = {'name': 'GCCcore', 'version': '11.2.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['e6d4c76be82c676dd7e8c61a29b2ac8510ae108a810b5d1d18fc9a1d2c9a2497']
+
+builddependencies = [
+    ('binutils', '2.37'),
+    ('pkg-config', '0.29.2'),
+    ('Perl', '5.34.0'),
+]
+dependencies = [
+    ('PCRE', '8.45'),
+    ('libidn2', '2.3.2'),
+    ('zlib', '1.2.11'),
+    ('OpenSSL', '1.1', '', SYSTEM),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date gnutls for security reasons
+    # ('GnuTLS', '3.7.1'),
+]
+
+# make sure pkg-config picks up system packages (OpenSSL & co)
+preconfigopts = "export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/cvmfs/soft.ccr.buffalo.edu/versions/2023.01/easybuild/software/Core/openssl/1.1/lib/pkgconfig && "
+configopts = '--with-ssl=openssl '
+
+# Optionally, you can use gnutls (default) instead of OpenSSL.
+# Do not forget to comment out configopts in that case.
+# osdependencies = [('gnutls-devel', 'gnutls-dev', 'libgnutls-devel')]
+
+sanity_check_paths = {
+    'files': ['bin/%(name)s'],
+    'dirs': []
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
This PR includes updated EB recipes for aria2 and roary and their dependencies.  

NOTE: Roary also required additional Perl modules to be installed, which was handled outside Easybuild by updating the existing perl/5.34.0 install.  [See here](https://github.com/sanger-pathogens/Roary/blob/master/README.md#installing-from-source-advanced-linux-users-only) under Perl dependencies