### PR TITLE
SeqKit version 2.7.0

### DIFF
--- a/config/easybuild/easyconfigs/SeqKit-2.7.0.eb
+++ b/config/easybuild/easyconfigs/SeqKit-2.7.0.eb
@@ -1,0 +1,26 @@
+easyblock = 'GoPackage'
+
+name = 'SeqKit'
+version = '2.7.0'
+
+homepage = 'https://bioinf.shenwei.me/seqkit/'
+description = """SeqKit - a cross-platform and ultrafast toolkit for FASTA/Q file manipulation"""
+
+toolchain = SYSTEM
+
+source_urls = ['https://github.com/shenwei356/seqkit/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['b5c723ffd4640659860fc70a71c218d8f53bea0eae571cecc98eff04c7291e02']
+
+builddependencies = [
+    ('Go', '1.20.4'),
+]
+
+installopts = './%(namelower)s'
+
+sanity_check_commands = [
+    "seqkit version",
+    "seqkit genautocomplete"
+]
+
+moduleclass = 'bio'


### PR DESCRIPTION
SeqKit version 2.7.0 easyconfig file

Note: requires go 1.20 or above to compile

Tony