### PR TITLE
nanopolish versions 0.13.3 and 0.14.0

### DIFF
--- a/config/easybuild/easyconfigs/VBZ-Compression-1.0.3-gompi-2021b.eb
+++ b/config/easybuild/easyconfigs/VBZ-Compression-1.0.3-gompi-2021b.eb
@@ -1,0 +1,43 @@
+easyblock = 'CMakeMake'
+
+name = 'VBZ-Compression'
+version = '1.0.3'
+
+homepage = 'https://github.com/nanoporetech/vbz_compression'
+description = "VBZ compression HDF5 plugin for nanopolish"
+
+toolchain = {'name': 'gompi', 'version': '2021b'}
+
+source_urls = [
+    'https://github.com/nanoporetech/vbz_compression/archive',
+    'https://github.com/lemire/streamvbyte/archive',
+]
+sources = [
+    {'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ},
+    {'download_filename': 'v0.4.1.tar.gz', 'filename': 'streamvbyte-v0.4.1.tar.gz'},
+]
+checksums = [
+    'a7450e076db628681bbc0e2b3f941c6c21cc2981a7e1c78628807ffdf1b34f31',  # VBZ-Compression-1.0.3.tar.gz
+    '4c4e53134a60b0b06816d3faa7dcde28c3e5e8a656dd415d16d80ae6e3d39fcc',  # streamvbyte-v0.4.1.tar.gz
+]
+
+builddependencies = [('CMake', '3.22.1')]
+
+dependencies = [
+    ('HDF5', '1.12.1'),
+    ('zstd', '1.5.0'),
+]
+
+preconfigopts = "rmdir %(builddir)s/vbz_compression*/third_party/streamvbyte && "
+preconfigopts += "mv %(builddir)s/streamvbyte-* %(builddir)s/streamvbyte && "
+preconfigopts += "mv %(builddir)s/streamvbyte %(builddir)s/vbz_compression*/third_party/. && "
+configopts = "-DENABLE_CONAN=OFF -DENABLE_PERF_TESTING=OFF -DENABLE_PYTHON=OFF "
+
+sanity_check_paths = {
+    'files': ['hdf5/lib/plugin/libvbz_hdf_plugin.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+modextrapaths = {'HDF5_PLUGIN_PATH': 'hdf5/lib/plugin/'}
+
+moduleclass = 'lib'

--- a/config/easybuild/easyconfigs/fast5-0.6.5-detail_Util_wrap_fix.patch
+++ b/config/easybuild/easyconfigs/fast5-0.6.5-detail_Util_wrap_fix.patch
@@ -1,0 +1,46 @@
+--- ./fast5-0.6.5/include/fast5/hdf5_tools.hpp.orig	2024-02-14 15:53:38.760440702 -0500
++++ ./fast5-0.6.5/include/fast5/hdf5_tools.hpp	2024-02-14 15:53:55.907734579 -0500
+@@ -8,6 +8,7 @@
+ #ifndef __HDF5_TOOLS_HPP
+ #define __HDF5_TOOLS_HPP
+ 
++#include <array>
+ #include <cassert>
+ #include <cstring>
+ #include <exception>
+@@ -2106,7 +2107,11 @@
+             detail::Util::wrap(H5Oopen, _file_id, loc_full_name.c_str(), H5P_DEFAULT),
+             detail::Util::wrapped_closer(H5Oclose));
+         H5O_info_t info;
++#if H5_VERSION_GE(1, 12, 0)
++        detail::Util::wrap(H5Oget_info, id_holder.id, &info, H5O_INFO_NUM_ATTRS);
++#else
+         detail::Util::wrap(H5Oget_info, id_holder.id, &info);
++#endif
+         // num_attrs in info.num_attrs
+         for (unsigned i = 0; i < (unsigned)info.num_attrs; ++i)
+         {
+@@ -2386,7 +2391,11 @@
+                 detail::Util::wrapped_closer(H5Oclose));
+             // check object is a group
+             H5O_info_t o_info;
++#if H5_VERSION_GE(1, 12, 0)
++            detail::Util::wrap(H5Oget_info, o_id_holder.id, &o_info, H5O_INFO_BASIC);
++#else
+             detail::Util::wrap(H5Oget_info, o_id_holder.id, &o_info);
++#endif
+             if (o_info.type != H5O_TYPE_GROUP) return false;
+         }
+         return true;
+@@ -2407,7 +2416,11 @@
+             detail::Util::wrapped_closer(H5Oclose));
+         // check object is a group
+         H5O_info_t o_info;
++#if H5_VERSION_GE(1, 12, 0)
++        detail::Util::wrap(H5Oget_info, o_id_holder.id, &o_info, H5O_INFO_BASIC);
++#else
+         detail::Util::wrap(H5Oget_info, o_id_holder.id, &o_info);
++#endif
+         return o_info.type == type_id;
+     } // check_object_type()
+ }; // class File

--- a/config/easybuild/easyconfigs/nanopolish-0.13.3-foss-2021b.eb
+++ b/config/easybuild/easyconfigs/nanopolish-0.13.3-foss-2021b.eb
@@ -1,0 +1,58 @@
+easyblock = 'MakeCp'
+
+name = 'nanopolish'
+version = '0.13.3'
+
+homepage = 'https://github.com/jts/nanopolish'
+description = "Software package for signal-level analysis of Oxford Nanopore sequencing data."
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+source_urls = [
+    'https://github.com/jts/nanopolish/archive/',
+    'https://github.com/mateidavid/fast5/archive/',
+]
+sources = [
+    {'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ},
+    {'download_filename': 'v0.6.5.tar.gz', 'filename': 'fast5-v0.6.5.tar.gz'},
+]
+patches = [
+    ('fast5-0.6.5-detail_Util_wrap_fix.patch', '%(builddir)s'),
+]
+checksums = [
+    'eac02b7db76f223375e246fa361a0a4fbf74021b9094573e5324fd7f75743d55',  # nanopolish-0.13.3.tar.gz
+    'f8b1ce2c07adb56b4f13337ef008e124255f86cdb7e74e4233afa8dca878ee1a',  # fast5-v0.6.5.tar.gz
+    '342d83ba4ab54a0e44a27fd0234e05bae80ef0bb96540f40966f2c87b09a118d',  # fast5-0.6.5-detail_Util_wrap_fix.patch
+]
+
+builddependencies = [('Eigen', '3.4.0')]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('Python', '3.9.6'),
+    ('Biopython', '1.79'),
+    ('Pysam', '0.18.0'),
+    ('HDF5', '1.12.1'),
+    ('HTSlib', '1.14'),
+    ('minimap2', '2.22'),
+    ('VBZ-Compression', '1.0.3'),
+]
+
+prebuildopts = "rmdir fast5 && ln -s %(builddir)s/fast5-*/ fast5 && "
+buildopts = "HDF5=noinstall EIGEN=noinstall HTS=noinstall MINIMAP2=noinstall"
+#buildopts += ' HDF5_INCLUDE_DIR="${HDF5_DIR}/include" HDF5_LIB_DIR="${HDF5_DIR}/lib" '
+
+runtest = 'test ' + buildopts
+
+files_to_copy = [(['nanopolish'], 'bin'), 'scripts']
+
+postinstallcmds = ["chmod a+rx %(installdir)s/scripts/*"]
+
+sanity_check_paths = {
+    'files': ['bin/nanopolish'],
+    'dirs': ['scripts'],
+}
+
+modextrapaths = {'PATH': 'scripts'}
+
+moduleclass = 'bio'

--- a/config/easybuild/easyconfigs/nanopolish-0.14.0-foss-2021b.eb
+++ b/config/easybuild/easyconfigs/nanopolish-0.14.0-foss-2021b.eb
@@ -1,0 +1,54 @@
+easyblock = 'MakeCp'
+
+name = 'nanopolish'
+version = '0.14.0'
+
+homepage = 'https://github.com/jts/nanopolish'
+description = "Software package for signal-level analysis of Oxford Nanopore sequencing data."
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+source_urls = [
+    'https://github.com/jts/nanopolish/archive/',
+    'https://github.com/hasindu2008/slow5lib/archive/',
+]
+sources = [
+    {'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCE_TAR_GZ},
+    {'download_filename': 'v1.1.0.tar.gz', 'filename': 'slow5lib-v1.1.0.tar.gz'},
+]
+checksums = [
+    'bcc1a7e2d23941592d817da3af9165b3843ae52b11a3ca5983d6417f1614ef78',  # nanopolish-0.14.0.tar.gz
+    'f13f08b85a9a11086b5d9378251093d1858d0dc29d8e727eabacfa57a73f4277',  # slow5lib-v1.1.0.tar.gz
+]
+
+builddependencies = [('Eigen', '3.4.0')]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('Python', '3.9.6'),
+    ('Biopython', '1.79'),
+    ('Pysam', '0.18.0'),
+    ('HDF5', '1.12.1'),
+    ('HTSlib', '1.14'),
+    ('minimap2', '2.22'),
+    ('VBZ-Compression', '1.0.3'),
+]
+
+prebuildopts = "if test -d slow5lib; then rmdir slow5lib; ln -s %(builddir)s/slow5lib-*/ slow5lib; fi && "
+buildopts = "HDF5=noinstall EIGEN=noinstall HTS=noinstall MINIMAP2=noinstall"
+#buildopts += ' HDF5_INCLUDE_DIR="${HDF5_DIR}/include" HDF5_LIB_DIR="${HDF5_DIR}/lib" '
+
+runtest = 'test ' + buildopts
+
+files_to_copy = [(['nanopolish'], 'bin'), 'scripts']
+
+postinstallcmds = ["chmod a+rx %(installdir)s/scripts/*"]
+
+sanity_check_paths = {
+    'files': ['bin/nanopolish'],
+    'dirs': ['scripts'],
+}
+
+modextrapaths = {'PATH': 'scripts'}
+
+moduleclass = 'bio'


### PR DESCRIPTION
nanopolish versions 0.13.3 and 0.14.0 easyconfig files

includes
    VBZ-Compression version 1.0.3

Note:
nanopolish version 0.13.3 - uses the Fast5 library for fast5 files
nanopolish version 0.14.0 - uses the newer slow5lib library for SLOW files

The newer version does not include the Fast5 library, and there is no indication that the slow5lib library reads fast5 files.

Tony