### PR TITLE
Fixed setting environment variables for Amber

### DIFF
--- a/config/easybuild/easyconfigs/Amber-22.0-foss-2021b-AmberTools-23.0-CUDA-11.8.0.eb
+++ b/config/easybuild/easyconfigs/Amber-22.0-foss-2021b-AmberTools-23.0-CUDA-11.8.0.eb
@@ -86,9 +86,11 @@ runtest = False
 
 static = False
 
-modextrapaths = {'PERL5LIB': 'lib/perl'}
-modextrapaths = {'QUICK_BASIS': 'AmberTools/src/quick/basis'}
-modextrapaths = {'PATH': 'bin/wrapped_progs'}
+modextravars = {'QUICK_BASIS': '%(installdir)s/AmberTools/src/quick/basis'}
+modextrapaths = {
+    'PERL5LIB': 'lib/perl',
+    'PATH': 'bin/wrapped_progs',
+}
 
 modloadmsg = """
 

--- a/config/easybuild/easyconfigs/Amber-22.0-foss-2021b-AmberTools-23.0.eb
+++ b/config/easybuild/easyconfigs/Amber-22.0-foss-2021b-AmberTools-23.0.eb
@@ -83,9 +83,11 @@ runtest = True
 
 static = False
 
-modextrapaths = {'PERL5LIB': 'lib/perl'}
-modextrapaths = {'QUICK_BASIS': 'AmberTools/src/quick/basis'}
-modextrapaths = {'PATH': 'bin/wrapped_progs'}
+modextravars = {'QUICK_BASIS': '%(installdir)s/AmberTools/src/quick/basis'}
+modextrapaths = {
+    'PERL5LIB': 'lib/perl',
+    'PATH': 'bin/wrapped_progs',
+}
 
 modloadmsg = """
 

--- a/config/easybuild/easyconfigs/CoordgenLibs-3.0.1-gompi-2021b.eb
+++ b/config/easybuild/easyconfigs/CoordgenLibs-3.0.1-gompi-2021b.eb
@@ -1,0 +1,32 @@
+easyblock = 'CMakeMake'
+
+name = 'CoordgenLibs'
+version = '3.0.1'
+
+homepage = 'https://github.com/schrodinger/coordgenlibs'
+description = "Schrodinger-developed 2D Coordinate Generation"
+
+toolchain = {'name': 'gompi', 'version': '2021b'}
+
+source_urls = ['https://github.com/schrodinger/coordgenlibs/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['737fd081bcb8a6913aa00b375be96458fe2821a58209c98e7a7e86a64d73a900']
+
+builddependencies = [('CMake', '3.22.1')]
+
+dependencies = [
+    ('Boost', '1.79.0'),
+    ('maeparser', '1.3.0'),
+]
+
+configopts = "-Dmaeparser_DIR=$EBROOTMAEPARSER/lib/cmake"
+
+# work around compiler warning treated as error by stripping out use of -Werror
+prebuildopts = "sed -i 's/-Werror//g' CMakeFiles/coordgen.dir/flags.make && "
+
+sanity_check_paths = {
+    'files': ['lib/libcoordgen.%s' % SHLIB_EXT],
+    'dirs': ['include/coordgen', 'lib/cmake'],
+}
+
+moduleclass = 'chem'

--- a/config/easybuild/easyconfigs/OpenBabel-3.1.1-gompi-2021b.eb
+++ b/config/easybuild/easyconfigs/OpenBabel-3.1.1-gompi-2021b.eb
@@ -1,0 +1,61 @@
+name = 'OpenBabel'
+version = '3.1.1'
+
+homepage = 'https://openbabel.org'
+description = """Open Babel is a chemical toolbox designed to speak the many
+ languages of chemical data. It's an open, collaborative project allowing anyone
+ to search, convert, analyze, or store data from molecular modeling, chemistry,
+ solid-state materials, biochemistry, or related areas."""
+
+toolchain = {'name': 'gompi', 'version': '2021b'}
+# avoid failing tests on skylake and broadwell CPUs.
+# remove option 'optarch' when building on CPUs that don't support AVX2
+# see also: https://github.com/openbabel/openbabel/issues/2138
+toolchainopts = {'pic': True, 'optarch': 'mavx2'}
+
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ['%%(namelower)s-%s.tar.gz' % version.replace('.', '-')]
+patches = [
+    # Fix test failure with Python 3
+    # Ref: https://github.com/openbabel/openbabel/commit/7de27f309db5f7ec026ef5c5235e5b33bf7d1a85.patch
+    'OpenBabel-3.1.1_fix-distgeom-test.patch',
+    'OpenBabel-3.1.1_fix-CoordgenLibs-no-templates.patch',
+]
+checksums = [
+    'c97023ac6300d26176c97d4ef39957f06e68848d64f1a04b0b284ccff2744f02',  # openbabel-3-1-1.tar.gz
+    '8d7687eb49142bb5ba2997cf90805b42480f313515c44b3912a9f826aaf4fbcd',  # OpenBabel-3.1.1_fix-distgeom-test.patch
+    # OpenBabel-3.1.1_fix-CoordgenLibs-no-templates.patch
+    'cc0396b38a78ef70c869cd93887210c64d6f4293c016aec9269b5a0230fdb51c',
+]
+
+builddependencies = [
+    ('CMake', '3.22.1'),
+    ('SWIG', '4.0.2'),
+]
+dependencies = [
+    ('Python', '3.9.6'),
+    ('zlib', '1.2.11'),
+    ('libxml2', '2.9.10'),
+    ('Eigen', '3.4.0'),
+    ('RapidJSON', '1.1.0'),
+    ('cairo', '1.16.0'),  # optional: for .png output
+    ('Boost', '1.79.0'),
+    ('maeparser', '1.3.0'),
+    ('CoordgenLibs', '3.0.1'),
+]
+
+configopts = '-DBoost_INCLUDE_DIR=$EBROOTBOOST/include -DBoost_LIBRARY_DIR_RELEASE=$EBROOTBOOST/lib '
+# Enable support for OpenMP compilation of forcefield code (optional)
+configopts += '-DENABLE_OPENMP=ON '
+
+# OpenBabel-3.1.1 creates directories named 3.1.0, which leads to BABEL_LIBDIR and BABEL_DATDIR
+# (set in the easyblock) having invalid values.  Work around this with some symlinks.
+postinstallcmds = [
+    'ln -s %(installdir)s/lib/openbabel/3.1.0 %(installdir)s/lib/openbabel/%(version)s',
+    'ln -s %(installdir)s/share/openbabel/3.1.0 %(installdir)s/share/openbabel/%(version)s',
+]
+
+pretestopts = 'cp lib/_openbabel.%s %%(builddir)s/openbabel-*/scripts/python/openbabel/ && ' % SHLIB_EXT
+runtest = 'test'
+
+moduleclass = 'chem'

--- a/config/easybuild/easyconfigs/maeparser-1.3.0-gompi-2021b.eb
+++ b/config/easybuild/easyconfigs/maeparser-1.3.0-gompi-2021b.eb
@@ -1,0 +1,26 @@
+easyblock = 'CMakeMake'
+
+name = 'maeparser'
+version = '1.3.0'
+
+homepage = 'https://github.com/schrodinger/maeparser'
+description = "maeparser is a parser for Schrodinger Maestro files."
+
+toolchain = {'name': 'gompi', 'version': '2021b'}
+
+source_urls = ['https://github.com/schrodinger/maeparser/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['fa8f9336de1e5d1cabec29a6da04547b1fb040bb32ba511ff30b4a14097c751c']
+
+builddependencies = [
+    ('CMake', '3.22.1'),
+]
+
+dependencies = [('Boost', '1.79.0')]
+
+sanity_check_paths = {
+    'files': ['lib/libmaeparser.%s' % SHLIB_EXT],
+    'dirs': ['include/maeparser', 'lib/cmake'],
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
Fixed Amber easyconfig files

Added OpenBabel version 3.1.1 to add hydrogen atoms to a pdb file (see https://ambermd.org/tutorials/basic/tutorial4b ) which includes:
    maeparser version 1.3.0
    CoordgenLibs version 3.0.1

Tony