### PR TITLE
Updated HUMAnN, DIAMOND and MetaPhlAn

### DIFF
--- a/config/easybuild/easyconfigs/d/DIAMOND/DIAMOND-2.1.11-GCC-11.2.0.eb
+++ b/config/easybuild/easyconfigs/d/DIAMOND/DIAMOND-2.1.11-GCC-11.2.0.eb
@@ -1,0 +1,25 @@
+easyblock = 'CMakeMake'
+
+name = 'DIAMOND'
+version = '2.1.11'
+
+homepage = 'https://github.com/bbuchfink/diamond'
+description = "Accelerated BLAST compatible local sequence aligner"
+
+toolchain = {'name': 'GCC', 'version': '11.2.0'}
+
+github_account = 'bbuchfink'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['e669e74ac4a7e45d86024a6b9bfda0642fabb02a8b6ce90a2ec7fb3aeb0f8233']
+
+builddependencies = [('CMake', '3.21.1')]
+dependencies = [('zlib', '1.2.11')]
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': [],
+}
+sanity_check_commands = ["%(namelower)s help"]
+
+moduleclass = 'bio'

--- a/config/easybuild/easyconfigs/h/humann/humann-3.9-foss-2021b.eb
+++ b/config/easybuild/easyconfigs/h/humann/humann-3.9-foss-2021b.eb
@@ -2,7 +2,7 @@
 easyblock = 'PythonBundle'
 
 name = 'humann'
-version = '3.6'
+version = '3.9'
 
 homepage = 'http://huttenhower.sph.harvard.edu/humann'
 
@@ -32,7 +32,7 @@ exts_list = [
 	],
         'patches': ['%(name)s-3.6_config_path.patch'],
         'checksums': [
-	    'addce81db58bacfdd5465423455d25e385aa8dd14349253c3a7054bf7d3747dc',  # humann-3.6.tar.gz
+	    'd018ddbbe45f5e3e11080620b4ae5f1737ba213d2c8cecdc8237859f853b2287',  # humann-3.9.tar.gz
 	    '6b3509608d8c9abf976b9c5d0c5715fdc700d03ee388c7997c3f37373fa58b56',  # humann-3.6_config_path.patch
 	],
         'postinstallcmds': ['cp humann/tools/create-user-config-file "%(installdir)s/bin/" && chmod 755 "%(installdir)s/bin/create-user-config-file"'],

--- a/config/easybuild/easyconfigs/m/MetaPhlAn/MetaPhlAn-4.1.1-foss-2021b.eb
+++ b/config/easybuild/easyconfigs/m/MetaPhlAn/MetaPhlAn-4.1.1-foss-2021b.eb
@@ -1,0 +1,50 @@
+# Contribution by
+# DeepThought, Flinders University
+# R.QIAO <rob.qiao@flinders.edu.au>
+
+easyblock = 'PythonBundle'
+
+name = 'MetaPhlAn'
+version = '4.1.1'
+
+homepage = 'https://github.com/biobakery/MetaPhlAn'
+description = """MetaPhlAn is a computational tool for profiling the composition
+ of microbial communities from metagenomic shotgun sequencing data """
+
+toolchain = {'name': 'foss', 'version': '2021b'}
+
+dependencies = [
+    ('Python', '3.9.6'),
+    ('SciPy-bundle', '2021.10'),
+    ('Biopython', '1.79'),
+    ('Pysam', '0.18.0'),
+    ('DendroPy', '4.5.2'),
+    ('CMSeq', '1.0.4'),
+    ('biom-format', '2.1.12'),
+    ('h5py', '3.6.0'),
+    ('PhyloPhlAn', '3.0.3'),
+    ('DIAMOND', '2.1.11'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('hclust2', '1.0.0', {
+        'checksums': ['9667f1d16628940aedd3d1d571b956a6f77795018e3ea4dd83f234419eb0096d'],
+    }),
+    (name, version, {
+        'checksums': ['b7b3ce7a0a4fab8f1d87fb19f53143ffe2de989fb2c13649ddc297b480a4ee54'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['%(namelower)s', 'strainphlan']],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/'],
+}
+
+sanity_check_commands = ["metaphlan -h"]
+
+sanity_pip_check = True
+
+moduleclass = 'bio'
+


### PR DESCRIPTION
The example from the HUMAnN sourecs runs to completion with these three updated modules.

HUMAnN & MetaPhlAn example setup:

module load gcc/11.2.0 openmpi/4.1.1 ucx/1.13.1 humann/3.9 metaphlan/4.1.1 mkdir -p /projects/academic/[YourGroupName]/databases/ cd /projects/academic/[YourGroupName]/databases/
create-user-config-file humann.cfg
export HUMAnN_CONFIG="/projects/academic/[YourGroupName]/databases/humann.cfg" mkdir -p chocophlan uniref utility_mapping
cd /projects/academic/[YourGroupName]/databases/chocophlan gzip -dc /util/software/data/HUMAnN/full_chocophlan.v201901_v31.tar.gz | tar xvf - humann_config --update database_folders nucleotide /projects/academic/[YourGroupName]/databases/chocophlan cd /projects/academic/[YourGroupName]/databases/uniref gzip -dc /util/software/data/HUMAnN/uniref90_annotated_v201901b_full.tar.gz | tar xvf - humann_config --update database_folders protein /projects/academic/[YourGroupName]/databases/uniref cd /projects/academic/[YourGroupName]/databases/utility_mapping gzip -dc /util/software/data/HUMAnN/full_mapping_v201901b.tar.gz | tar xvf - humann_config --update database_folders utility_mapping /projects/academic/[YourGroupName]/databases/utility_mapping cd /projects/academic/[YourGroupName]/databases
mkdir metaphlan_databases
cd metaphlan_databases
cp /util/software/data/MetaPhlAn/*
export METAPHLAN_DB_DIR="/projects/academic/[YourGroupName]/databases/metaphlan_databases"

For each HUMAnN & MetaPhlAn job, whether interactive or a Slurm job submission always use:

module load gcc/11.2.0 openmpi/4.1.1 ucx/1.13.1 humann/3.9 metaphlan/4.1.1 export HUMAnN_CONFIG="/projects/academic/[YourGroupName]/databases/humann.cfg" export METAPHLAN_DB_DIR="/projects/academic/[YourGroupName]/databases/metaphlan_databases"

Tony