### PR TITLE
OpenMPI version 4.1.6 with Java support easyconfig

### DIFF
--- a/config/easybuild/2024.04/ccrsoft.py
+++ b/config/easybuild/2024.04/ccrsoft.py
@@ -58,7 +58,7 @@ CHANGES = {
     },
     'OpenMPI': {
         'builddependencies': ({'x86_64': [('opa-psm2', '12.0.1')]}.get(os.getenv('CCR_CPU_FAMILY'), []), Op.APPEND_LIST),
-        'preconfigopts': ('LDFLAGS="-L/usr/lib/x86_64-linux-gnu/slurm" ', Op.APPEND),
+        'preconfigopts': ('LDFLAGS="-L/usr/lib/$(arch)-linux-gnu/slurm" ', Op.APPEND),
         'configopts': ('--with-slurm --with-pmi=/opt/software/slurm --with-hwloc=external ', Op.PREPEND),
         # See: https://github.com/easybuilders/easybuild-easyconfigs/issues/20233
         'modluafooter': ('setenv("OMPI_MCA_btl", "^ofi")\nsetenv("OMPI_MCA_mtl", "^ofi")', Op.APPEND),

--- a/config/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.6-GCC-13.2.0.eb
+++ b/config/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.6-GCC-13.2.0.eb
@@ -1,0 +1,70 @@
+name = 'OpenMPI'
+version = '4.1.6'
+
+homepage = 'https://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-3 implementation."""
+
+toolchain = {'name': 'GCC', 'version': '13.2.0'}
+
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+sources = [SOURCELOWER_TAR_BZ2]
+patches = [
+    'OpenMPI-4.1.1_build-with-internal-cuda-header.patch',
+    'OpenMPI-4.1.1_opal-datatype-cuda-performance.patch',
+    'OpenMPI-4.1.x_add_atomic_wmb.patch',
+]
+checksums = [
+    {'openmpi-4.1.6.tar.bz2': 'f740994485516deb63b5311af122c265179f5328a0d857a567b85db00b11e415'},
+    {'OpenMPI-4.1.1_build-with-internal-cuda-header.patch':
+     '63eac52736bdf7644c480362440a7f1f0ae7c7cae47b7565f5635c41793f8c83'},
+    {'OpenMPI-4.1.1_opal-datatype-cuda-performance.patch':
+     'b767c7166cf0b32906132d58de5439c735193c9fd09ec3c5c11db8d5fa68750e'},
+    {'OpenMPI-4.1.x_add_atomic_wmb.patch': '9494bbc546d661ba5189e44b4c84a7f8df30a87cdb9d96ce2e73a7c8fecba172'},
+]
+
+builddependencies = [
+    ('pkgconf', '2.0.3'),
+    ('Perl', '5.38.0'),
+    ('Autotools', '20220317'),
+]
+
+dependencies = [
+    ('zlib', '1.2.13'),
+    ('hwloc', '2.9.2'),
+    ('libevent', '2.1.12'),
+    ('UCX', '1.15.0'),
+    ('libfabric', '1.19.0'),
+    ('PMIx', '4.2.6'),
+    ('UCC', '1.2.0'),
+    ('Java', '21.0.2', '', SYSTEM),
+]
+
+# Update configure to include changes from the "internal-cuda" patch
+# The intention here was to running a subset of autogen.pl sufficient
+# to achieve the cuda change, but for autoconf > 2.69 we have to
+# run the full autogen.pl
+preconfigopts = ' && '.join([
+    'cd config',
+    'autom4te --language=m4sh opal_get_version.m4sh -o opal_get_version.sh',
+    'cd ..',
+    './autogen.pl --force',
+    'autoconf',
+    'autoheader',
+    'aclocal',
+    'automake',
+    ''
+])
+
+# CUDA related patches and custom configure option can be removed if CUDA support isn't wanted.
+configopts = '--with-cuda=internal '
+
+# disable MPI1 compatibility for now, see what breaks...
+# configopts += '--enable-mpi1-compatibility '
+
+# enable Java support
+configopts += '--enable-mpi-java --with-jdk-bindir="${EBROOTJAVA}/bin" --with-jdk-headers="${EBROOTJAVA}/include" '
+
+# to enable SLURM integration (site-specific)
+configopts += '--with-slurm --with-pmi="/opt/software/slurm" '
+
+moduleclass = 'mpi'


### PR DESCRIPTION
OpenMPI version 4.1.6, with Java and Slurm options added

Includes a fix for ARM64 MPI/Slurm LDFLAGS in ccrsoft.py


Tony